### PR TITLE
Add create_sample_table procedure to Iceberg connector

### DIFF
--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/CreateTableSampleProcedure.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/CreateTableSampleProcedure.java
@@ -1,0 +1,73 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.iceberg;
+
+import com.facebook.airlift.log.Logger;
+import com.facebook.presto.hive.HdfsEnvironment;
+import com.facebook.presto.spi.ConnectorSession;
+import com.facebook.presto.spi.procedure.Procedure;
+import com.google.common.collect.ImmutableList;
+
+import javax.inject.Inject;
+import javax.inject.Provider;
+
+import java.lang.invoke.MethodHandle;
+
+import static com.facebook.presto.common.block.MethodHandleUtil.methodHandle;
+import static com.facebook.presto.common.type.StandardTypes.VARCHAR;
+
+public class CreateTableSampleProcedure
+        implements Provider<Procedure>
+{
+    private static final Logger LOG = Logger.get(CreateTableSampleProcedure.class);
+
+    private static final MethodHandle CREATE_TABLE_SAMPLE = methodHandle(
+            CreateTableSampleProcedure.class,
+            "createTableSample",
+            ConnectorSession.class,
+            String.class,
+            String.class);
+
+    @Inject
+    public CreateTableSampleProcedure(
+            IcebergConfig config,
+            IcebergMetadataFactory metadataFactory,
+            HdfsEnvironment hdfsEnvironment,
+            IcebergResourceFactory resourceFactory)
+    {
+//        this.metadataFactory = requireNonNull(metadataFactory, "metadataFactory is null");
+//        this.hdfsEnvironment = requireNonNull(hdfsEnvironment, "hdfsEnvironment is null");
+//        this.resourceFactory = requireNonNull(resourceFactory, "resourceFactory is null");
+//        requireNonNull(config, "config is null");
+//        this.catalogType = config.getCatalogType();
+    }
+
+    @Override
+    public Procedure get()
+    {
+        return new Procedure(
+                "system",
+                "create_table_sample",
+                ImmutableList.of(
+                        new Procedure.Argument("schema", VARCHAR),
+                        new Procedure.Argument("table", VARCHAR)),
+                CREATE_TABLE_SAMPLE.bindTo(this));
+    }
+
+    public void createTableSample(ConnectorSession clientSession, String schema, String table)
+    {
+        // TODO(zac) implement sample procedure
+        throw new RuntimeException("Procedure not yet implemented");
+    }
+}

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/CreateTableSampleProcedure.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/CreateTableSampleProcedure.java
@@ -14,30 +14,53 @@
 package com.facebook.presto.iceberg;
 
 import com.facebook.airlift.log.Logger;
+import com.facebook.presto.hive.HdfsContext;
 import com.facebook.presto.hive.HdfsEnvironment;
+import com.facebook.presto.hive.metastore.ExtendedHiveMetastore;
+import com.facebook.presto.iceberg.util.SinglePathCatalog;
 import com.facebook.presto.spi.ConnectorSession;
+import com.facebook.presto.spi.SchemaTableName;
+import com.facebook.presto.spi.connector.ConnectorMetadata;
 import com.facebook.presto.spi.procedure.Procedure;
 import com.google.common.collect.ImmutableList;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+import org.apache.iceberg.Table;
+import org.apache.iceberg.catalog.Catalog;
+import org.apache.iceberg.catalog.TableIdentifier;
 
 import javax.inject.Inject;
 import javax.inject.Provider;
 
+import java.io.IOException;
 import java.lang.invoke.MethodHandle;
+import java.util.HashMap;
 
 import static com.facebook.presto.common.block.MethodHandleUtil.methodHandle;
 import static com.facebook.presto.common.type.StandardTypes.VARCHAR;
+import static com.facebook.presto.iceberg.CatalogType.HADOOP;
+import static com.facebook.presto.iceberg.CatalogType.NESSIE;
+import static com.facebook.presto.iceberg.IcebergUtil.getHiveIcebergTable;
+import static com.facebook.presto.iceberg.util.IcebergPrestoModelConverters.toIcebergTableIdentifier;
+import static java.util.Objects.requireNonNull;
 
 public class CreateTableSampleProcedure
         implements Provider<Procedure>
 {
     private static final Logger LOG = Logger.get(CreateTableSampleProcedure.class);
 
+    public static final String SAMPLE_TABLE_SUFFIX = "sample-table";
     private static final MethodHandle CREATE_TABLE_SAMPLE = methodHandle(
             CreateTableSampleProcedure.class,
             "createTableSample",
             ConnectorSession.class,
             String.class,
             String.class);
+
+    private IcebergConfig config;
+    private IcebergMetadataFactory metadataFactory;
+    private HdfsEnvironment hdfsEnvironment;
+    private IcebergResourceFactory resourceFactory;
 
     @Inject
     public CreateTableSampleProcedure(
@@ -46,11 +69,10 @@ public class CreateTableSampleProcedure
             HdfsEnvironment hdfsEnvironment,
             IcebergResourceFactory resourceFactory)
     {
-//        this.metadataFactory = requireNonNull(metadataFactory, "metadataFactory is null");
-//        this.hdfsEnvironment = requireNonNull(hdfsEnvironment, "hdfsEnvironment is null");
-//        this.resourceFactory = requireNonNull(resourceFactory, "resourceFactory is null");
-//        requireNonNull(config, "config is null");
-//        this.catalogType = config.getCatalogType();
+        this.config = requireNonNull(config);
+        this.metadataFactory = requireNonNull(metadataFactory);
+        this.hdfsEnvironment = requireNonNull(hdfsEnvironment);
+        this.resourceFactory = requireNonNull(resourceFactory);
     }
 
     @Override
@@ -65,9 +87,45 @@ public class CreateTableSampleProcedure
                 CREATE_TABLE_SAMPLE.bindTo(this));
     }
 
+    /**
+     * Not yet implemented.
+     * <p>
+     * Creates a new table sample alongside the given iceberg table with the
+     * given schema and table name.
+     *
+     * @param clientSession the client's session information
+     * @param schema the schema where the table exists
+     * @param table the name of the table to sample from
+     */
     public void createTableSample(ConnectorSession clientSession, String schema, String table)
     {
-        // TODO(zac) implement sample procedure
-        throw new RuntimeException("Procedure not yet implemented");
+        SchemaTableName schemaTableName = new SchemaTableName(schema, table);
+        ConnectorMetadata metadata = metadataFactory.create();
+        Table icebergTable;
+        CatalogType catalogType = config.getCatalogType();
+
+        if (catalogType == HADOOP || catalogType == NESSIE) {
+            icebergTable = resourceFactory.getCatalog(clientSession).loadTable(toIcebergTableIdentifier(schema, table));
+        }
+        else {
+            ExtendedHiveMetastore metastore = ((IcebergHiveMetadata) metadata).getMetastore();
+            icebergTable = getHiveIcebergTable(metastore, hdfsEnvironment, clientSession, schemaTableName);
+        }
+        String location = icebergTable.location();
+        Path tableLocation = new Path(location);
+        HdfsContext context = new HdfsContext(clientSession, schema, table, location, false);
+        try {
+            FileSystem fs = hdfsEnvironment.getFileSystem(context, tableLocation);
+            Path samplePath = new Path(tableLocation, SAMPLE_TABLE_SUFFIX);
+            Catalog c = new SinglePathCatalog(samplePath, fs);
+            c.initialize(samplePath.getName(), new HashMap<>());
+            TableIdentifier id = toIcebergTableIdentifier("sample", SAMPLE_TABLE_SUFFIX);
+            // create the table for samples and load the table back to make sure it's valid
+            c.createTable(id, icebergTable.schema());
+            c.loadTable(id);
+        }
+        catch (IOException e) {
+            LOG.warn("failed to create sample table", e);
+        }
     }
 }

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergModule.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergModule.java
@@ -161,6 +161,7 @@ public class IcebergModule
 
         Multibinder<Procedure> procedures = newSetBinder(binder, Procedure.class);
         procedures.addBinding().toProvider(RollbackToSnapshotProcedure.class).in(Scopes.SINGLETON);
+        procedures.addBinding().toProvider(CreateTableSampleProcedure.class).in(Scopes.SINGLETON);
 
         // for orc
         binder.bind(EncryptionLibrary.class).annotatedWith(HiveDwrfEncryptionProvider.ForCryptoService.class).to(UnsupportedEncryptionLibrary.class).in(Scopes.SINGLETON);

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/util/SinglePathCatalog.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/util/SinglePathCatalog.java
@@ -1,0 +1,111 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.iceberg.util;
+
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+import org.apache.iceberg.CatalogProperties;
+import org.apache.iceberg.Table;
+import org.apache.iceberg.catalog.Namespace;
+import org.apache.iceberg.catalog.TableIdentifier;
+import org.apache.iceberg.hadoop.HadoopCatalog;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+import static java.util.Objects.requireNonNull;
+
+/**
+ * This class is an implementation of an Iceberg catalog that can load a table from a single
+ * path in a filesystem. It must directly point to the top-level directory of a single table
+ * which contains all the standard files and metadata for a table.
+ * <p>
+ * The path location must be accessible through the Hadoop {@link FileSystem} client.
+ * <p>
+ * There is no namespacing associated with this catalog. It will always return a single table
+ * no matter the namespace that is provided. You cannot drop or rename the table either.
+ */
+public class SinglePathCatalog
+        extends HadoopCatalog
+{
+    private final Path path;
+    private final FileSystem fs;
+
+    public SinglePathCatalog(Path path, FileSystem fs)
+    {
+        this.path = requireNonNull(path);
+        this.fs = requireNonNull(fs);
+    }
+
+    @Override
+    public void initialize(String name, Map<String, String> properties)
+    {
+        properties.put(CatalogProperties.WAREHOUSE_LOCATION, path.getParent().toString());
+        this.setConf(fs.getConf());
+        super.initialize(name, properties);
+    }
+
+    @Override
+    public List<TableIdentifier> listTables(Namespace namespace)
+    {
+        return Collections.singletonList(TableIdentifier.of(namespace, path.getName()));
+    }
+
+    @Override
+    public boolean dropTable(TableIdentifier identifier, boolean purge)
+    {
+        throw unsupportedOp();
+    }
+
+    @Override
+    public void renameTable(TableIdentifier from, TableIdentifier to)
+    {
+        throw unsupportedOp();
+    }
+
+    @Override
+    public void createNamespace(Namespace namespace)
+    {
+        throw unsupportedOp();
+    }
+
+    @Override
+    public void createNamespace(Namespace namespace, Map<String, String> meta)
+    {
+        throw unsupportedOp();
+    }
+
+    @Override
+    public boolean dropNamespace(Namespace namespace)
+    {
+        throw unsupportedOp();
+    }
+
+    @Override
+    public Table registerTable(TableIdentifier identifier, String metadataFileLocation)
+    {
+        throw unsupportedOp();
+    }
+
+    private RuntimeException unsupportedOp()
+    {
+        return new UnsupportedOperationException("Can't " + getCallerMethodName(2) + " in " + SinglePathCatalog.class.getName());
+    }
+
+    private String getCallerMethodName(int idx)
+    {
+        return new Throwable().getStackTrace()[idx].getMethodName();
+    }
+}

--- a/presto-iceberg/src/test/java/com/facebook/presto/iceberg/TestIcebergSystemTables.java
+++ b/presto-iceberg/src/test/java/com/facebook/presto/iceberg/TestIcebergSystemTables.java
@@ -194,6 +194,12 @@ public class TestIcebergSystemTables
     }
 
     @Test
+    public void testSamplesTable()
+    {
+        assertUpdate("CALL iceberg.system.create_table_sample('test_schema', 'test_table')");
+    }
+
+    @Test
     public void testFilesTableOnDropColumn()
     {
         assertQuery("SELECT sum(record_count) FROM test_schema.\"test_table_drop_column$files\"", "VALUES 6");


### PR DESCRIPTION
This change introduces a new system procedure which creates a table to store row samples from an existing iceberg table. This change only introduces the creation of the tables. They cannot be queried or updated yet.

Example usage:

```
CALL iceberg.system.create_sample_table('<schema>', '<table_name>');
```