### PR TITLE
Query Iceberg Sample Table

### DIFF
--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/CreateTableSampleProcedure.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/CreateTableSampleProcedure.java
@@ -29,9 +29,18 @@ import org.apache.iceberg.Table;
 import org.apache.iceberg.catalog.Catalog;
 import org.apache.iceberg.catalog.TableIdentifier;
 import com.facebook.presto.hive.HdfsEnvironment;
+import com.facebook.presto.hive.metastore.ExtendedHiveMetastore;
+import com.facebook.presto.iceberg.util.SinglePathCatalog;
 import com.facebook.presto.spi.ConnectorSession;
+import com.facebook.presto.spi.SchemaTableName;
+import com.facebook.presto.spi.connector.ConnectorMetadata;
 import com.facebook.presto.spi.procedure.Procedure;
 import com.google.common.collect.ImmutableList;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+import org.apache.iceberg.Table;
+import org.apache.iceberg.catalog.Catalog;
+import org.apache.iceberg.catalog.TableIdentifier;
 
 import javax.inject.Inject;
 import javax.inject.Provider;
@@ -48,9 +57,15 @@ import static com.facebook.presto.iceberg.IcebergUtil.getHiveIcebergTable;
 import static com.facebook.presto.iceberg.util.IcebergPrestoModelConverters.toIcebergTableIdentifier;
 import static java.util.Objects.requireNonNull;
 import java.lang.invoke.MethodHandle;
+import java.util.HashMap;
 
 import static com.facebook.presto.common.block.MethodHandleUtil.methodHandle;
 import static com.facebook.presto.common.type.StandardTypes.VARCHAR;
+import static com.facebook.presto.iceberg.CatalogType.HADOOP;
+import static com.facebook.presto.iceberg.CatalogType.NESSIE;
+import static com.facebook.presto.iceberg.IcebergUtil.getHiveIcebergTable;
+import static com.facebook.presto.iceberg.util.IcebergPrestoModelConverters.toIcebergTableIdentifier;
+import static java.util.Objects.requireNonNull;
 
 public class CreateTableSampleProcedure
         implements Provider<Procedure>

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/CreateTableSampleProcedure.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/CreateTableSampleProcedure.java
@@ -26,19 +26,6 @@ import com.google.common.collect.ImmutableList;
 import org.apache.hadoop.fs.Path;
 import org.apache.iceberg.Table;
 import org.apache.iceberg.catalog.TableIdentifier;
-import com.facebook.presto.hive.HdfsEnvironment;
-import com.facebook.presto.hive.metastore.ExtendedHiveMetastore;
-import com.facebook.presto.iceberg.util.SinglePathCatalog;
-import com.facebook.presto.spi.ConnectorSession;
-import com.facebook.presto.spi.SchemaTableName;
-import com.facebook.presto.spi.connector.ConnectorMetadata;
-import com.facebook.presto.spi.procedure.Procedure;
-import com.google.common.collect.ImmutableList;
-import org.apache.hadoop.fs.FileSystem;
-import org.apache.hadoop.fs.Path;
-import org.apache.iceberg.Table;
-import org.apache.iceberg.catalog.Catalog;
-import org.apache.iceberg.catalog.TableIdentifier;
 
 import javax.inject.Inject;
 import javax.inject.Provider;
@@ -53,16 +40,6 @@ import static com.facebook.presto.iceberg.CatalogType.HADOOP;
 import static com.facebook.presto.iceberg.CatalogType.NESSIE;
 import static com.facebook.presto.iceberg.IcebergUtil.getHiveIcebergTable;
 import static com.facebook.presto.iceberg.samples.SampleUtil.SAMPLE_TABLE_SUFFIX;
-import static com.facebook.presto.iceberg.util.IcebergPrestoModelConverters.toIcebergTableIdentifier;
-import static java.util.Objects.requireNonNull;
-import java.lang.invoke.MethodHandle;
-import java.util.HashMap;
-
-import static com.facebook.presto.common.block.MethodHandleUtil.methodHandle;
-import static com.facebook.presto.common.type.StandardTypes.VARCHAR;
-import static com.facebook.presto.iceberg.CatalogType.HADOOP;
-import static com.facebook.presto.iceberg.CatalogType.NESSIE;
-import static com.facebook.presto.iceberg.IcebergUtil.getHiveIcebergTable;
 import static com.facebook.presto.iceberg.util.IcebergPrestoModelConverters.toIcebergTableIdentifier;
 import static java.util.Objects.requireNonNull;
 

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/CreateTableSampleProcedure.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/CreateTableSampleProcedure.java
@@ -23,10 +23,8 @@ import com.facebook.presto.spi.SchemaTableName;
 import com.facebook.presto.spi.connector.ConnectorMetadata;
 import com.facebook.presto.spi.procedure.Procedure;
 import com.google.common.collect.ImmutableList;
-import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
 import org.apache.iceberg.Table;
-import org.apache.iceberg.catalog.Catalog;
 import org.apache.iceberg.catalog.TableIdentifier;
 import com.facebook.presto.hive.HdfsEnvironment;
 import com.facebook.presto.hive.metastore.ExtendedHiveMetastore;
@@ -54,6 +52,7 @@ import static com.facebook.presto.common.type.StandardTypes.VARCHAR;
 import static com.facebook.presto.iceberg.CatalogType.HADOOP;
 import static com.facebook.presto.iceberg.CatalogType.NESSIE;
 import static com.facebook.presto.iceberg.IcebergUtil.getHiveIcebergTable;
+import static com.facebook.presto.iceberg.samples.SampleUtil.SAMPLE_TABLE_SUFFIX;
 import static com.facebook.presto.iceberg.util.IcebergPrestoModelConverters.toIcebergTableIdentifier;
 import static java.util.Objects.requireNonNull;
 import java.lang.invoke.MethodHandle;
@@ -71,8 +70,6 @@ public class CreateTableSampleProcedure
         implements Provider<Procedure>
 {
     private static final Logger LOG = Logger.get(CreateTableSampleProcedure.class);
-
-    public static final String SAMPLE_TABLE_SUFFIX = "sample-table";
     private static final MethodHandle CREATE_TABLE_SAMPLE = methodHandle(
             CreateTableSampleProcedure.class,
             "createTableSample",
@@ -80,10 +77,10 @@ public class CreateTableSampleProcedure
             String.class,
             String.class);
 
-    private IcebergConfig config;
-    private IcebergMetadataFactory metadataFactory;
-    private HdfsEnvironment hdfsEnvironment;
-    private IcebergResourceFactory resourceFactory;
+    private final IcebergConfig config;
+    private final IcebergMetadataFactory metadataFactory;
+    private final HdfsEnvironment hdfsEnvironment;
+    private final IcebergResourceFactory resourceFactory;
 
     @Inject
     public CreateTableSampleProcedure(
@@ -111,8 +108,6 @@ public class CreateTableSampleProcedure
     }
 
     /**
-     * Not yet implemented.
-     * <p>
      * Creates a new table sample alongside the given iceberg table with the
      * given schema and table name.
      *
@@ -137,18 +132,15 @@ public class CreateTableSampleProcedure
         String location = icebergTable.location();
         Path tableLocation = new Path(location);
         HdfsContext context = new HdfsContext(clientSession, schema, table, location, false);
-        try {
-            FileSystem fs = hdfsEnvironment.getFileSystem(context, tableLocation);
+        try (SinglePathCatalog c = new SinglePathCatalog(tableLocation, hdfsEnvironment.getConfiguration(context, tableLocation))) {
             Path samplePath = new Path(tableLocation, SAMPLE_TABLE_SUFFIX);
-            Catalog c = new SinglePathCatalog(samplePath, fs);
             c.initialize(samplePath.getName(), new HashMap<>());
             TableIdentifier id = toIcebergTableIdentifier("sample", SAMPLE_TABLE_SUFFIX);
             // create the table for samples and load the table back to make sure it's valid
             c.createTable(id, icebergTable.schema());
-            c.loadTable(id);
         }
         catch (IOException e) {
-            LOG.warn("failed to create sample table", e);
+            LOG.warn("Failed to create sample table", e);
         }
     }
 }

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/CreateTableSampleProcedure.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/CreateTableSampleProcedure.java
@@ -28,6 +28,10 @@ import org.apache.hadoop.fs.Path;
 import org.apache.iceberg.Table;
 import org.apache.iceberg.catalog.Catalog;
 import org.apache.iceberg.catalog.TableIdentifier;
+import com.facebook.presto.hive.HdfsEnvironment;
+import com.facebook.presto.spi.ConnectorSession;
+import com.facebook.presto.spi.procedure.Procedure;
+import com.google.common.collect.ImmutableList;
 
 import javax.inject.Inject;
 import javax.inject.Provider;
@@ -43,6 +47,10 @@ import static com.facebook.presto.iceberg.CatalogType.NESSIE;
 import static com.facebook.presto.iceberg.IcebergUtil.getHiveIcebergTable;
 import static com.facebook.presto.iceberg.util.IcebergPrestoModelConverters.toIcebergTableIdentifier;
 import static java.util.Objects.requireNonNull;
+import java.lang.invoke.MethodHandle;
+
+import static com.facebook.presto.common.block.MethodHandleUtil.methodHandle;
+import static com.facebook.presto.common.type.StandardTypes.VARCHAR;
 
 public class CreateTableSampleProcedure
         implements Provider<Procedure>

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergAbstractMetadata.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergAbstractMetadata.java
@@ -53,7 +53,6 @@ import org.apache.iceberg.types.Type;
 import org.apache.iceberg.types.TypeUtil;
 import org.apache.iceberg.types.Types;
 
-import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
@@ -65,7 +64,6 @@ import java.util.concurrent.atomic.AtomicInteger;
 
 import static com.facebook.presto.common.type.BigintType.BIGINT;
 import static com.facebook.presto.iceberg.IcebergColumnHandle.primitiveIcebergColumnHandle;
-import static com.facebook.presto.iceberg.IcebergErrorCode.ICEBERG_FILESYSTEM_ERROR;
 import static com.facebook.presto.iceberg.IcebergUtil.getColumns;
 import static com.facebook.presto.iceberg.IcebergUtil.getFileFormat;
 import static com.facebook.presto.iceberg.IcebergUtil.resolveSnapshotIdByName;
@@ -204,12 +202,7 @@ public abstract class IcebergAbstractMetadata
                 insertTable = icebergTable;
                 break;
             case SAMPLES:
-                try {
                     insertTable = SampleUtil.getSampleTableFromActual(icebergTable, table.getSchemaName(), env, session);
-                }
-                catch (IOException e) {
-                    throw new PrestoException(ICEBERG_FILESYSTEM_ERROR, e);
-                }
                 break;
             default:
                 throw new PrestoException(NOT_SUPPORTED, "can only write to data or samples table");

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergAbstractMetadata.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergAbstractMetadata.java
@@ -16,7 +16,9 @@ package com.facebook.presto.iceberg;
 import com.facebook.airlift.json.JsonCodec;
 import com.facebook.airlift.log.Logger;
 import com.facebook.presto.common.type.TypeManager;
+import com.facebook.presto.hive.HdfsEnvironment;
 import com.facebook.presto.hive.HiveWrittenPartitions;
+import com.facebook.presto.iceberg.samples.SampleUtil;
 import com.facebook.presto.spi.ColumnHandle;
 import com.facebook.presto.spi.ColumnMetadata;
 import com.facebook.presto.spi.ConnectorInsertTableHandle;
@@ -42,7 +44,6 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import io.airlift.slice.Slice;
 import org.apache.iceberg.AppendFiles;
-import org.apache.iceberg.BaseTable;
 import org.apache.iceberg.DataFiles;
 import org.apache.iceberg.PartitionSpecParser;
 import org.apache.iceberg.Schema;
@@ -52,6 +53,7 @@ import org.apache.iceberg.types.Type;
 import org.apache.iceberg.types.TypeUtil;
 import org.apache.iceberg.types.Types;
 
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
@@ -63,15 +65,11 @@ import java.util.concurrent.atomic.AtomicInteger;
 
 import static com.facebook.presto.common.type.BigintType.BIGINT;
 import static com.facebook.presto.iceberg.IcebergColumnHandle.primitiveIcebergColumnHandle;
-import static com.facebook.presto.iceberg.IcebergTableProperties.FILE_FORMAT_PROPERTY;
-import static com.facebook.presto.iceberg.IcebergTableProperties.FORMAT_VERSION;
-import static com.facebook.presto.iceberg.IcebergTableProperties.PARTITIONING_PROPERTY;
+import static com.facebook.presto.iceberg.IcebergErrorCode.ICEBERG_FILESYSTEM_ERROR;
 import static com.facebook.presto.iceberg.IcebergUtil.getColumns;
 import static com.facebook.presto.iceberg.IcebergUtil.getFileFormat;
 import static com.facebook.presto.iceberg.IcebergUtil.resolveSnapshotIdByName;
-import static com.facebook.presto.iceberg.PartitionFields.toPartitionFields;
 import static com.facebook.presto.iceberg.TypeConverter.toIcebergType;
-import static com.facebook.presto.iceberg.TypeConverter.toPrestoType;
 import static com.facebook.presto.spi.StandardErrorCode.NOT_SUPPORTED;
 import static com.google.common.collect.ImmutableList.toImmutableList;
 import static java.util.Collections.singletonList;
@@ -139,6 +137,8 @@ public abstract class IcebergAbstractMetadata
                 return Optional.of(new FilesTable(systemTableName, table, snapshotId, typeManager));
             case PROPERTIES:
                 return Optional.of(new PropertiesTable(systemTableName, table));
+//            case SAMPLES:
+//                return Optional.of(new SamplesSystemTable(tableName.getSchemaName()))
         }
         return Optional.empty();
     }
@@ -196,19 +196,35 @@ public abstract class IcebergAbstractMetadata
         return finishInsert(session, (IcebergWritableTableHandle) tableHandle, fragments, computedStatistics);
     }
 
-    protected ConnectorInsertTableHandle beginIcebergTableInsert(IcebergTableHandle table, org.apache.iceberg.Table icebergTable)
+    protected ConnectorInsertTableHandle beginIcebergTableInsert(ConnectorSession session, IcebergTableHandle table, org.apache.iceberg.Table icebergTable, HdfsEnvironment env)
     {
-        transaction = icebergTable.newTransaction();
+        org.apache.iceberg.Table insertTable;
+        switch (table.getTableType()) {
+            case DATA:
+                insertTable = icebergTable;
+                break;
+            case SAMPLES:
+                try {
+                    insertTable = SampleUtil.getSampleTableFromActual(icebergTable, table.getSchemaName(), env, session);
+                }
+                catch (IOException e) {
+                    throw new PrestoException(ICEBERG_FILESYSTEM_ERROR, e);
+                }
+                break;
+            default:
+                throw new PrestoException(NOT_SUPPORTED, "can only write to data or samples table");
+        }
+        transaction = insertTable.newTransaction();
 
         return new IcebergWritableTableHandle(
                 table.getSchemaName(),
                 table.getTableName(),
-                SchemaParser.toJson(icebergTable.schema()),
-                PartitionSpecParser.toJson(icebergTable.spec()),
-                getColumns(icebergTable.schema(), typeManager),
-                icebergTable.location(),
+                SchemaParser.toJson(insertTable.schema()),
+                PartitionSpecParser.toJson(insertTable.spec()),
+                getColumns(insertTable.schema(), typeManager),
+                insertTable.location(),
                 getFileFormat(icebergTable),
-                icebergTable.properties());
+                insertTable.properties());
     }
 
     @Override
@@ -266,33 +282,6 @@ public abstract class IcebergAbstractMetadata
     public ConnectorTableHandle beginDelete(ConnectorSession session, ConnectorTableHandle tableHandle)
     {
         throw new PrestoException(NOT_SUPPORTED, "This connector only supports delete where one or more partitions are deleted entirely");
-    }
-
-    protected List<ColumnMetadata> getColumnMetadatas(org.apache.iceberg.Table table)
-    {
-        return table.schema().columns().stream()
-                .map(column -> ColumnMetadata.builder()
-                        .setName(column.name())
-                        .setType(toPrestoType(column.type(), typeManager))
-                        .setComment(Optional.ofNullable(column.doc()))
-                        .setHidden(false)
-                        .build())
-                .collect(toImmutableList());
-    }
-
-    protected ImmutableMap<String, Object> createMetadataProperties(org.apache.iceberg.Table icebergTable)
-    {
-        ImmutableMap.Builder<String, Object> properties = ImmutableMap.builder();
-        properties.put(FILE_FORMAT_PROPERTY, getFileFormat(icebergTable));
-
-        int formatVersion = ((BaseTable) icebergTable).operations().current().formatVersion();
-        properties.put(FORMAT_VERSION, String.valueOf(formatVersion));
-
-        if (!icebergTable.spec().fields().isEmpty()) {
-            properties.put(PARTITIONING_PROPERTY, toPartitionFields(icebergTable.spec()));
-        }
-
-        return properties.build();
     }
 
     protected static Schema toIcebergSchema(List<ColumnMetadata> columns)

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergHiveMetadata.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergHiveMetadata.java
@@ -133,12 +133,7 @@ public class IcebergHiveMetadata
 
         org.apache.iceberg.Table table = getHiveIcebergTable(metastore, hdfsEnvironment, session, new SchemaTableName(tableName.getSchemaName(), name.getTableName()));
         if (name.getTableType() == SAMPLES) {
-            try {
-                table = SampleUtil.getSampleTableFromActual(table, tableName.getSchemaName(), hdfsEnvironment, session);
-            }
-            catch (IOException e) {
-                LOG.warn("Failed to get sample table", e);
-            }
+            table = SampleUtil.getSampleTableFromActual(table, tableName.getSchemaName(), hdfsEnvironment, session);
         }
         Optional<Long> snapshotId = getSnapshotId(table, name.getSnapshotId());
 

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergMetadataFactory.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergMetadataFactory.java
@@ -57,7 +57,7 @@ public class IcebergMetadataFactory
         switch (catalogType) {
             case HADOOP:
             case NESSIE:
-                return new IcebergNativeMetadata(resourceFactory, typeManager, commitTaskCodec, catalogType);
+                return new IcebergNativeMetadata(resourceFactory, hdfsEnvironment, typeManager, commitTaskCodec, catalogType);
             case HIVE:
                 return new IcebergHiveMetadata(metastore, hdfsEnvironment, typeManager, commitTaskCodec);
         }

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergNativeMetadata.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergNativeMetadata.java
@@ -49,7 +49,6 @@ import org.apache.iceberg.exceptions.AlreadyExistsException;
 import org.apache.iceberg.exceptions.NamespaceNotEmptyException;
 import org.apache.iceberg.exceptions.NoSuchTableException;
 
-import java.io.IOException;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -132,10 +131,6 @@ public class IcebergNativeMetadata
         }
         catch (NoSuchTableException e) {
             // return null to throw
-            return null;
-        }
-        catch (IOException e) {
-            LOG.warn("Failed to get table handle: ", e);
             return null;
         }
 

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergNativeMetadata.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergNativeMetadata.java
@@ -14,9 +14,12 @@
 package com.facebook.presto.iceberg;
 
 import com.facebook.airlift.json.JsonCodec;
+import com.facebook.airlift.log.Logger;
 import com.facebook.presto.common.predicate.TupleDomain;
 import com.facebook.presto.common.type.TypeManager;
+import com.facebook.presto.hive.HdfsEnvironment;
 import com.facebook.presto.hive.TableAlreadyExistsException;
+import com.facebook.presto.iceberg.samples.SampleUtil;
 import com.facebook.presto.iceberg.util.IcebergPrestoModelConverters;
 import com.facebook.presto.spi.ColumnHandle;
 import com.facebook.presto.spi.ColumnMetadata;
@@ -46,6 +49,7 @@ import org.apache.iceberg.exceptions.AlreadyExistsException;
 import org.apache.iceberg.exceptions.NamespaceNotEmptyException;
 import org.apache.iceberg.exceptions.NoSuchTableException;
 
+import java.io.IOException;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -54,12 +58,15 @@ import static com.facebook.presto.iceberg.IcebergErrorCode.ICEBERG_INVALID_SNAPS
 import static com.facebook.presto.iceberg.IcebergTableProperties.getFileFormat;
 import static com.facebook.presto.iceberg.IcebergTableProperties.getFormatVersion;
 import static com.facebook.presto.iceberg.IcebergTableProperties.getPartitioning;
+import static com.facebook.presto.iceberg.IcebergUtil.createMetadataProperties;
+import static com.facebook.presto.iceberg.IcebergUtil.getColumnMetadatas;
 import static com.facebook.presto.iceberg.IcebergUtil.getColumns;
 import static com.facebook.presto.iceberg.IcebergUtil.getNativeIcebergTable;
 import static com.facebook.presto.iceberg.IcebergUtil.getTableComment;
 import static com.facebook.presto.iceberg.IcebergUtil.resolveSnapshotIdByName;
 import static com.facebook.presto.iceberg.PartitionFields.parsePartitionFields;
 import static com.facebook.presto.iceberg.TableType.DATA;
+import static com.facebook.presto.iceberg.TableType.SAMPLES;
 import static com.facebook.presto.iceberg.TypeConverter.toIcebergType;
 import static com.facebook.presto.iceberg.util.IcebergPrestoModelConverters.toIcebergNamespace;
 import static com.facebook.presto.iceberg.util.IcebergPrestoModelConverters.toIcebergTableIdentifier;
@@ -78,14 +85,17 @@ import static org.apache.iceberg.TableProperties.FORMAT_VERSION;
 public class IcebergNativeMetadata
         extends IcebergAbstractMetadata
 {
+    private static final Logger LOG = Logger.get(IcebergNativeMetadata.class);
     private static final String INFORMATION_SCHEMA = "information_schema";
     private static final String TABLE_COMMENT = "comment";
 
     private final IcebergResourceFactory resourceFactory;
     private final CatalogType catalogType;
+    private final HdfsEnvironment hdfsEnvironment;
 
     public IcebergNativeMetadata(
             IcebergResourceFactory resourceFactory,
+            HdfsEnvironment hdfsEnvironment,
             TypeManager typeManager,
             JsonCodec<CommitTaskData> commitTaskCodec,
             CatalogType catalogType)
@@ -93,6 +103,7 @@ public class IcebergNativeMetadata
         super(typeManager, commitTaskCodec);
         this.resourceFactory = requireNonNull(resourceFactory, "resourceFactory is null");
         this.catalogType = requireNonNull(catalogType, "catalogType is null");
+        this.hdfsEnvironment = requireNonNull(hdfsEnvironment, "hdfsEnvironment is null");
     }
 
     @Override
@@ -109,15 +120,22 @@ public class IcebergNativeMetadata
     public IcebergTableHandle getTableHandle(ConnectorSession session, SchemaTableName tableName)
     {
         IcebergTableName name = IcebergTableName.from(tableName.getTableName());
-        verify(name.getTableType() == DATA, "Wrong table type: " + name.getTableType());
+        verify(name.getTableType() == DATA || name.getTableType() == SAMPLES, "Wrong table type: " + name.getTableType());
         TableIdentifier tableIdentifier = toIcebergTableIdentifier(tableName.getSchemaName(), name.getTableName());
 
         Table table;
         try {
             table = resourceFactory.getCatalog(session).loadTable(tableIdentifier);
+            if (name.getTableType() == SAMPLES) {
+                table = SampleUtil.getSampleTableFromActual(table, tableName.getSchemaName(), hdfsEnvironment, session);
+            }
         }
         catch (NoSuchTableException e) {
             // return null to throw
+            return null;
+        }
+        catch (IOException e) {
+            LOG.warn("Failed to get table handle: ", e);
             return null;
         }
 
@@ -262,7 +280,7 @@ public class IcebergNativeMetadata
         IcebergTableHandle table = (IcebergTableHandle) tableHandle;
         Table icebergTable = getNativeIcebergTable(resourceFactory, session, table.getSchemaTableName());
 
-        return beginIcebergTableInsert(table, icebergTable);
+        return beginIcebergTableInsert(session, table, icebergTable, hdfsEnvironment);
     }
 
     @Override
@@ -317,7 +335,7 @@ public class IcebergNativeMetadata
             throw new TableNotFoundException(table);
         }
 
-        List<ColumnMetadata> columns = getColumnMetadatas(icebergTable);
+        List<ColumnMetadata> columns = getColumnMetadatas(icebergTable, typeManager);
 
         return new ConnectorTableMetadata(table, columns, createMetadataProperties(icebergTable), getTableComment(icebergTable));
     }

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergSplitManager.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergSplitManager.java
@@ -20,7 +20,6 @@ import com.facebook.presto.spi.ConnectorSession;
 import com.facebook.presto.spi.ConnectorSplitSource;
 import com.facebook.presto.spi.ConnectorTableLayoutHandle;
 import com.facebook.presto.spi.FixedSplitSource;
-import com.facebook.presto.spi.PrestoException;
 import com.facebook.presto.spi.connector.ConnectorSplitManager;
 import com.facebook.presto.spi.connector.ConnectorTransactionHandle;
 import com.google.common.collect.ImmutableList;
@@ -30,12 +29,9 @@ import org.apache.iceberg.util.TableScanUtil;
 
 import javax.inject.Inject;
 
-import java.io.IOException;
-
 import static com.facebook.presto.iceberg.CatalogType.HADOOP;
 import static com.facebook.presto.iceberg.CatalogType.NESSIE;
 import static com.facebook.presto.iceberg.ExpressionConverter.toIcebergExpression;
-import static com.facebook.presto.iceberg.IcebergErrorCode.ICEBERG_FILESYSTEM_ERROR;
 import static com.facebook.presto.iceberg.IcebergSessionProperties.getMinimumAssignedSplitWeight;
 import static com.facebook.presto.iceberg.IcebergUtil.getHiveIcebergTable;
 import static com.facebook.presto.iceberg.IcebergUtil.getNativeIcebergTable;
@@ -86,12 +82,7 @@ public class IcebergSplitManager
             icebergTable = getHiveIcebergTable(metastore, hdfsEnvironment, session, table.getSchemaTableName());
         }
         if (table.getTableType() == TableType.SAMPLES) {
-            try {
-                icebergTable = SampleUtil.getSampleTableFromActual(icebergTable, table.getSchemaName(), hdfsEnvironment, session);
-            }
-            catch (IOException e) {
-                throw new PrestoException(ICEBERG_FILESYSTEM_ERROR, e);
-            }
+            icebergTable = SampleUtil.getSampleTableFromActual(icebergTable, table.getSchemaName(), hdfsEnvironment, session);
         }
 
         TableScan tableScan = icebergTable.newScan()

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergSplitManager.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergSplitManager.java
@@ -15,10 +15,12 @@ package com.facebook.presto.iceberg;
 
 import com.facebook.presto.hive.HdfsEnvironment;
 import com.facebook.presto.hive.metastore.ExtendedHiveMetastore;
+import com.facebook.presto.iceberg.samples.SampleUtil;
 import com.facebook.presto.spi.ConnectorSession;
 import com.facebook.presto.spi.ConnectorSplitSource;
 import com.facebook.presto.spi.ConnectorTableLayoutHandle;
 import com.facebook.presto.spi.FixedSplitSource;
+import com.facebook.presto.spi.PrestoException;
 import com.facebook.presto.spi.connector.ConnectorSplitManager;
 import com.facebook.presto.spi.connector.ConnectorTransactionHandle;
 import com.google.common.collect.ImmutableList;
@@ -28,9 +30,12 @@ import org.apache.iceberg.util.TableScanUtil;
 
 import javax.inject.Inject;
 
+import java.io.IOException;
+
 import static com.facebook.presto.iceberg.CatalogType.HADOOP;
 import static com.facebook.presto.iceberg.CatalogType.NESSIE;
 import static com.facebook.presto.iceberg.ExpressionConverter.toIcebergExpression;
+import static com.facebook.presto.iceberg.IcebergErrorCode.ICEBERG_FILESYSTEM_ERROR;
 import static com.facebook.presto.iceberg.IcebergSessionProperties.getMinimumAssignedSplitWeight;
 import static com.facebook.presto.iceberg.IcebergUtil.getHiveIcebergTable;
 import static com.facebook.presto.iceberg.IcebergUtil.getNativeIcebergTable;
@@ -79,6 +84,14 @@ public class IcebergSplitManager
         else {
             ExtendedHiveMetastore metastore = ((IcebergHiveMetadata) transactionManager.get(transaction)).getMetastore();
             icebergTable = getHiveIcebergTable(metastore, hdfsEnvironment, session, table.getSchemaTableName());
+        }
+        if (table.getTableType() == TableType.SAMPLES) {
+            try {
+                icebergTable = SampleUtil.getSampleTableFromActual(icebergTable, table.getSchemaName(), hdfsEnvironment, session);
+            }
+            catch (IOException e) {
+                throw new PrestoException(ICEBERG_FILESYSTEM_ERROR, e);
+            }
         }
 
         TableScan tableScan = icebergTable.newScan()

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergUtil.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergUtil.java
@@ -20,7 +20,9 @@ import com.facebook.presto.hive.HdfsEnvironment;
 import com.facebook.presto.hive.HiveColumnConverterProvider;
 import com.facebook.presto.hive.metastore.ExtendedHiveMetastore;
 import com.facebook.presto.hive.metastore.MetastoreContext;
+import com.facebook.presto.spi.ColumnMetadata;
 import com.facebook.presto.spi.ConnectorSession;
+import com.facebook.presto.spi.ConnectorTableMetadata;
 import com.facebook.presto.spi.PrestoException;
 import com.facebook.presto.spi.SchemaTableName;
 import com.google.common.collect.ImmutableMap;
@@ -45,6 +47,11 @@ import java.util.regex.Pattern;
 
 import static com.facebook.presto.hive.HiveMetadata.TABLE_COMMENT;
 import static com.facebook.presto.iceberg.IcebergErrorCode.ICEBERG_INVALID_SNAPSHOT_ID;
+import static com.facebook.presto.iceberg.IcebergTableProperties.FILE_FORMAT_PROPERTY;
+import static com.facebook.presto.iceberg.IcebergTableProperties.FORMAT_VERSION;
+import static com.facebook.presto.iceberg.IcebergTableProperties.PARTITIONING_PROPERTY;
+import static com.facebook.presto.iceberg.PartitionFields.toPartitionFields;
+import static com.facebook.presto.iceberg.TypeConverter.toPrestoType;
 import static com.facebook.presto.iceberg.util.IcebergPrestoModelConverters.toIcebergTableIdentifier;
 import static com.facebook.presto.spi.StandardErrorCode.NOT_SUPPORTED;
 import static com.google.common.collect.ImmutableList.toImmutableList;
@@ -85,6 +92,25 @@ public final class IcebergUtil
     public static Table getNativeIcebergTable(IcebergResourceFactory resourceFactory, ConnectorSession session, SchemaTableName table)
     {
         return resourceFactory.getCatalog(session).loadTable(toIcebergTableIdentifier(table));
+    }
+
+    public static ConnectorTableMetadata getTableMetadataFromTable(SchemaTableName tableName, Table icebergTable, TypeManager typeManager)
+    {
+        List<ColumnMetadata> columns = getColumnMetadatas(icebergTable, typeManager);
+
+        return new ConnectorTableMetadata(tableName, columns, createMetadataProperties(icebergTable), getTableComment(icebergTable));
+    }
+
+    public static List<ColumnMetadata> getColumnMetadatas(org.apache.iceberg.Table table, TypeManager typeManager)
+    {
+        return table.schema().columns().stream()
+                .map(column -> ColumnMetadata.builder()
+                        .setName(column.name())
+                        .setType(toPrestoType(column.type(), typeManager))
+                        .setComment(Optional.ofNullable(column.doc()))
+                        .setHidden(false)
+                        .build())
+                .collect(toImmutableList());
     }
 
     public static long resolveSnapshotId(Table table, long snapshotId)
@@ -136,6 +162,21 @@ public final class IcebergUtil
         return FileFormat.valueOf(table.properties()
                 .getOrDefault(DEFAULT_FILE_FORMAT, DEFAULT_FILE_FORMAT_DEFAULT)
                 .toUpperCase(Locale.ENGLISH));
+    }
+
+    public static ImmutableMap<String, Object> createMetadataProperties(org.apache.iceberg.Table icebergTable)
+    {
+        ImmutableMap.Builder<String, Object> properties = ImmutableMap.builder();
+        properties.put(FILE_FORMAT_PROPERTY, getFileFormat(icebergTable));
+
+        int formatVersion = ((BaseTable) icebergTable).operations().current().formatVersion();
+        properties.put(FORMAT_VERSION, String.valueOf(formatVersion));
+
+        if (!icebergTable.spec().fields().isEmpty()) {
+            properties.put(PARTITIONING_PROPERTY, toPartitionFields(icebergTable.spec()));
+        }
+
+        return properties.build();
     }
 
     public static Optional<String> getTableComment(Table table)

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/TableType.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/TableType.java
@@ -22,4 +22,5 @@ public enum TableType
     PARTITIONS,
     FILES,
     PROPERTIES,
+    SAMPLES,
 }

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/samples/SampleUtil.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/samples/SampleUtil.java
@@ -20,6 +20,7 @@ import com.facebook.presto.iceberg.IcebergHiveMetadata;
 import com.facebook.presto.iceberg.IcebergResourceFactory;
 import com.facebook.presto.iceberg.util.SinglePathCatalog;
 import com.facebook.presto.spi.ConnectorSession;
+import com.facebook.presto.spi.PrestoException;
 import com.facebook.presto.spi.SchemaTableName;
 import org.apache.hadoop.fs.Path;
 import org.apache.iceberg.Table;
@@ -28,6 +29,7 @@ import org.apache.iceberg.catalog.TableIdentifier;
 import java.io.IOException;
 import java.util.HashMap;
 
+import static com.facebook.presto.iceberg.IcebergErrorCode.ICEBERG_FILESYSTEM_ERROR;
 import static com.facebook.presto.iceberg.IcebergUtil.getHiveIcebergTable;
 import static com.facebook.presto.iceberg.util.IcebergPrestoModelConverters.toIcebergTableIdentifier;
 
@@ -49,7 +51,6 @@ public class SampleUtil
     }
 
     public static Table getSampleTableFromActual(Table icebergSource, String prestoSchema, HdfsEnvironment env, ConnectorSession session)
-            throws IOException
     {
         Path tableLocation = new Path(icebergSource.location());
         HdfsContext ctx = new HdfsContext(session, prestoSchema, icebergSource.name(), icebergSource.location(), false);
@@ -60,6 +61,9 @@ public class SampleUtil
             TableIdentifier id = toIcebergTableIdentifier("sample", SAMPLE_TABLE_SUFFIX);
             Table t = c.loadTable(id);
             return t;
+        }
+        catch (IOException e) {
+            throw new PrestoException(ICEBERG_FILESYSTEM_ERROR, e);
         }
     }
 }

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/samples/SampleUtil.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/samples/SampleUtil.java
@@ -1,0 +1,65 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.iceberg.samples;
+
+import com.facebook.presto.hive.HdfsContext;
+import com.facebook.presto.hive.HdfsEnvironment;
+import com.facebook.presto.hive.metastore.ExtendedHiveMetastore;
+import com.facebook.presto.iceberg.IcebergHiveMetadata;
+import com.facebook.presto.iceberg.IcebergResourceFactory;
+import com.facebook.presto.iceberg.util.SinglePathCatalog;
+import com.facebook.presto.spi.ConnectorSession;
+import com.facebook.presto.spi.SchemaTableName;
+import org.apache.hadoop.fs.Path;
+import org.apache.iceberg.Table;
+import org.apache.iceberg.catalog.TableIdentifier;
+
+import java.io.IOException;
+import java.util.HashMap;
+
+import static com.facebook.presto.iceberg.IcebergUtil.getHiveIcebergTable;
+import static com.facebook.presto.iceberg.util.IcebergPrestoModelConverters.toIcebergTableIdentifier;
+
+public class SampleUtil
+{
+    private SampleUtil() {}
+
+    public static final String SAMPLE_TABLE_SUFFIX = "sample-table";
+
+    public static Table getNativeTable(ConnectorSession session, IcebergResourceFactory resourceFactory, SchemaTableName table)
+    {
+        return resourceFactory.getCatalog(session).loadTable(toIcebergTableIdentifier(table.getSchemaName(), table.getTableName()));
+    }
+
+    public static Table getHiveTable(ConnectorSession session, IcebergHiveMetadata metadata, HdfsEnvironment env, SchemaTableName table)
+    {
+        ExtendedHiveMetastore metastore = metadata.getMetastore();
+        return getHiveIcebergTable(metastore, env, session, table);
+    }
+
+    public static Table getSampleTableFromActual(Table icebergSource, String prestoSchema, HdfsEnvironment env, ConnectorSession session)
+            throws IOException
+    {
+        Path tableLocation = new Path(icebergSource.location());
+        HdfsContext ctx = new HdfsContext(session, prestoSchema, icebergSource.name(), icebergSource.location(), false);
+        try (SinglePathCatalog c = new SinglePathCatalog(tableLocation, env.getConfiguration(ctx, tableLocation))) {
+            // initializing the catalog can be expensive. See if we can somehow store the catalog reference
+            // or wrap a delegate catalog.
+            c.initialize(tableLocation.getName(), new HashMap<>());
+            TableIdentifier id = toIcebergTableIdentifier("sample", SAMPLE_TABLE_SUFFIX);
+            Table t = c.loadTable(id);
+            return t;
+        }
+    }
+}

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/util/SinglePathCatalog.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/util/SinglePathCatalog.java
@@ -13,6 +13,7 @@
  */
 package com.facebook.presto.iceberg.util;
 
+import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
 import org.apache.iceberg.CatalogProperties;
@@ -21,6 +22,7 @@ import org.apache.iceberg.catalog.Namespace;
 import org.apache.iceberg.catalog.TableIdentifier;
 import org.apache.iceberg.hadoop.HadoopCatalog;
 
+import java.io.IOException;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -38,23 +40,29 @@ import static java.util.Objects.requireNonNull;
  * no matter the namespace that is provided. You cannot drop or rename the table either.
  */
 public class SinglePathCatalog
-        extends HadoopCatalog
+        extends HadoopCatalog implements AutoCloseable
 {
     private final Path path;
-    private final FileSystem fs;
+    private final Configuration conf;
 
-    public SinglePathCatalog(Path path, FileSystem fs)
+    public SinglePathCatalog(Path path, Configuration conf)
     {
         this.path = requireNonNull(path);
-        this.fs = requireNonNull(fs);
+        this.conf = requireNonNull(conf);
     }
 
     @Override
     public void initialize(String name, Map<String, String> properties)
     {
-        properties.put(CatalogProperties.WAREHOUSE_LOCATION, path.getParent().toString());
-        this.setConf(fs.getConf());
+        properties.put(CatalogProperties.WAREHOUSE_LOCATION, path.toString());
+        this.setConf(this.conf);
         super.initialize(name, properties);
+    }
+
+    @Override
+    public void close() throws IOException
+    {
+        super.close();
     }
 
     @Override


### PR DESCRIPTION
The "samples" table can be accessed similarly to the other table
types in iceberg by using the "$" system table syntax:

```
presto:tpch> CALL iceberg.system.create_table_sample('tpch', 'customer');

presto:tpch> SELECT * FROM "customer$samples";
 custkey | name | address | nationkey | phone | acctbal | mktsegment | comment
---------+------+---------+-----------+-------+---------+------------+---------
(0 rows)
```

The sample table always has the same schema as the normal DATA
type table, except during writing and reading the location points the
source and sink to a different location - the location of the sample
table.

One of the tricky parts is that since we're using the system table
syntax to hide the table from the configured catalog, the iceberg
code previously just reads/writes to the iceberg table directly since
a table name like "customer$samples" is parsed into a struct with
something like "{ name -> customer, tableType -> SAMPLES }". The
previous code before this change ignored the table type because
anything other than DATA would return a SystemTable.

SystemTable wasn't a viable implementation because we also needed
write support which SystemTable doesn't provide. So, this
implementation adds a few case statements to check the table type
to see if the sample table needs to be updated as well.

The last bit that needs to be changed after this commit is to support
iceberg's schema evolution. Currently, when querying the table
schema, the schema from the source table is always returned.
However if that schema gets updated, then we need to mirror that
change in the samples table if it exists.

So this implementation resorts to adding