### PR TITLE
Implement Iceberg changelog scanning

### DIFF
--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/CreateSampleTableProcedure.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/CreateSampleTableProcedure.java
@@ -23,6 +23,7 @@ import com.facebook.presto.spi.connector.ConnectorMetadata;
 import com.facebook.presto.spi.procedure.Procedure;
 import com.google.common.collect.ImmutableList;
 import org.apache.iceberg.Table;
+import org.apache.iceberg.UpdateProperties;
 
 import javax.inject.Inject;
 import javax.inject.Provider;
@@ -109,9 +110,11 @@ public class CreateSampleTableProcedure
             // create the table for samples and load the table back to make sure it's valid
             c.createTable(SAMPLE_TABLE_ID, icebergTable.schema());
         }
-        icebergTable.updateProperties()
-                .set(SAMPLE_TABLE_PRIMARY_KEY, primaryKey)
-                .set(SAMPLE_TABLE_LAST_SNAPSHOT, Long.toString(icebergTable.currentSnapshot().snapshotId()))
-                .commit();
+        UpdateProperties properties = icebergTable.updateProperties()
+                .set(SAMPLE_TABLE_PRIMARY_KEY, primaryKey);
+        if (icebergTable.currentSnapshot() != null) {
+            properties.set(SAMPLE_TABLE_LAST_SNAPSHOT, Long.toString(icebergTable.currentSnapshot().snapshotId()));
+        }
+        properties.commit();
     }
 }

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/DeleteSampleTableProcedure.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/DeleteSampleTableProcedure.java
@@ -104,5 +104,9 @@ public class DeleteSampleTableProcedure
         try (SampleUtil.AutoCloseableCatalog c = SampleUtil.getCatalogForSampleTable(icebergTable, schema, hdfsEnvironment, clientSession)) {
             c.dropTable(SAMPLE_TABLE_ID, true);
         }
+        icebergTable.updateProperties()
+                .remove(IcebergTableProperties.SAMPLE_TABLE_PRIMARY_KEY)
+                .remove(IcebergTableProperties.SAMPLE_TABLE_LAST_SNAPSHOT)
+                .commit();
     }
 }

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergAbstractMetadata.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergAbstractMetadata.java
@@ -15,9 +15,14 @@ package com.facebook.presto.iceberg;
 
 import com.facebook.airlift.json.JsonCodec;
 import com.facebook.airlift.log.Logger;
+import com.facebook.presto.common.type.NamedTypeSignature;
+import com.facebook.presto.common.type.RowFieldName;
+import com.facebook.presto.common.type.StandardTypes;
 import com.facebook.presto.common.type.TypeManager;
+import com.facebook.presto.common.type.TypeSignatureParameter;
 import com.facebook.presto.hive.HdfsEnvironment;
 import com.facebook.presto.hive.HiveWrittenPartitions;
+import com.facebook.presto.iceberg.changelog.ChangelogUtil;
 import com.facebook.presto.iceberg.samples.SampleUtil;
 import com.facebook.presto.spi.ColumnHandle;
 import com.facebook.presto.spi.ColumnMetadata;
@@ -48,6 +53,7 @@ import org.apache.iceberg.DataFiles;
 import org.apache.iceberg.PartitionSpecParser;
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.SchemaParser;
+import org.apache.iceberg.Table;
 import org.apache.iceberg.Transaction;
 import org.apache.iceberg.types.Type;
 import org.apache.iceberg.types.TypeUtil;
@@ -61,17 +67,25 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.Collectors;
 
 import static com.facebook.presto.common.type.BigintType.BIGINT;
 import static com.facebook.presto.iceberg.IcebergColumnHandle.primitiveIcebergColumnHandle;
+import static com.facebook.presto.iceberg.IcebergUtil.createMetadataProperties;
+import static com.facebook.presto.iceberg.IcebergUtil.getColumnMetadatas;
 import static com.facebook.presto.iceberg.IcebergUtil.getColumns;
 import static com.facebook.presto.iceberg.IcebergUtil.getFileFormat;
+import static com.facebook.presto.iceberg.IcebergUtil.getTableComment;
 import static com.facebook.presto.iceberg.IcebergUtil.resolveSnapshotIdByName;
+import static com.facebook.presto.iceberg.TableType.CHANGELOG;
 import static com.facebook.presto.iceberg.TypeConverter.toIcebergType;
+import static com.facebook.presto.iceberg.changelog.ChangelogUtil.getPrimaryKeyType;
 import static com.facebook.presto.spi.StandardErrorCode.NOT_SUPPORTED;
 import static com.google.common.collect.ImmutableList.toImmutableList;
+import static com.google.common.collect.ImmutableMap.toImmutableMap;
 import static java.util.Collections.singletonList;
 import static java.util.Objects.requireNonNull;
+import static java.util.function.Function.identity;
 
 public abstract class IcebergAbstractMetadata
         implements ConnectorMetadata
@@ -81,14 +95,17 @@ public abstract class IcebergAbstractMetadata
     protected final TypeManager typeManager;
     protected final JsonCodec<CommitTaskData> commitTaskCodec;
 
+    protected final HdfsEnvironment hdfsEnvironment;
+
     protected final Map<String, Optional<Long>> snapshotIds = new ConcurrentHashMap<>();
 
     protected Transaction transaction;
 
-    public IcebergAbstractMetadata(TypeManager typeManager, JsonCodec<CommitTaskData> commitTaskCodec)
+    public IcebergAbstractMetadata(TypeManager typeManager, JsonCodec<CommitTaskData> commitTaskCodec, HdfsEnvironment hdfsEnvironment)
     {
         this.typeManager = requireNonNull(typeManager, "typeManager is null");
         this.commitTaskCodec = requireNonNull(commitTaskCodec, "commitTaskCodec is null");
+        this.hdfsEnvironment = requireNonNull(hdfsEnvironment, "hdfsEnvironment is null");
     }
 
     @Override
@@ -112,7 +129,9 @@ public abstract class IcebergAbstractMetadata
         Optional<Long> snapshotId = resolveSnapshotIdByName(table, name);
 
         switch (name.getTableType()) {
+            case CHANGELOG:
             case DATA:
+            case SAMPLES:
                 break;
             case HISTORY:
                 if (name.getSnapshotId().isPresent()) {
@@ -135,8 +154,6 @@ public abstract class IcebergAbstractMetadata
                 return Optional.of(new FilesTable(systemTableName, table, snapshotId, typeManager));
             case PROPERTIES:
                 return Optional.of(new PropertiesTable(systemTableName, table));
-//            case SAMPLES:
-//                return Optional.of(new SamplesSystemTable(tableName.getSchemaName()))
         }
         return Optional.empty();
     }
@@ -144,10 +161,32 @@ public abstract class IcebergAbstractMetadata
     @Override
     public ConnectorTableMetadata getTableMetadata(ConnectorSession session, ConnectorTableHandle table)
     {
-        return getTableMetadata(session, ((IcebergTableHandle) table).getSchemaTableName());
+        IcebergTableHandle ith = (IcebergTableHandle) table;
+        return getChangelogTableMeta(session, ith.getSchemaTableNameWithType());
     }
 
-    protected abstract ConnectorTableMetadata getTableMetadata(ConnectorSession session, SchemaTableName table);
+    protected abstract Table getIcebergTable(ConnectorSession session, SchemaTableName table);
+
+
+
+    private ConnectorTableMetadata getChangelogTableMeta(ConnectorSession session, SchemaTableName table)
+    {
+        IcebergTableName itn = IcebergTableName.from(table.getTableName());
+        ConnectorTableMetadata tableMeta = getTableMetadata(session, table);
+        if (itn.getTableType() == CHANGELOG) {
+            String primaryKeyColumn = IcebergTableProperties.getSampleTablePrimaryKey(tableMeta.getProperties());
+            return ChangelogUtil.getChangelogTableMeta(table, getPrimaryKeyType(tableMeta, primaryKeyColumn), typeManager);
+        }
+        return tableMeta;
+    }
+
+    protected ConnectorTableMetadata getTableMetadata(ConnectorSession session, SchemaTableName table)
+    {
+        IcebergTableName ith = IcebergTableName.from(table.getTableName());
+        org.apache.iceberg.Table icebergTable = getIcebergTable(session, new SchemaTableName(table.getSchemaName(), ith.getTableName()));
+        List<ColumnMetadata> columns = getColumnMetadatas(icebergTable, typeManager);
+        return new ConnectorTableMetadata(table, columns, createMetadataProperties(icebergTable), getTableComment(icebergTable));
+    }
 
     @Override
     public Map<SchemaTableName, List<ColumnMetadata>> listTableColumns(ConnectorSession session, SchemaTablePrefix prefix)
@@ -157,7 +196,8 @@ public abstract class IcebergAbstractMetadata
         ImmutableMap.Builder<SchemaTableName, List<ColumnMetadata>> columns = ImmutableMap.builder();
         for (SchemaTableName table : tables) {
             try {
-                columns.put(table, getTableMetadata(session, table).getColumns());
+                ConnectorTableMetadata tableMeta = getChangelogTableMeta(session, table);
+                columns.put(table, tableMeta.getColumns());
             }
             catch (TableNotFoundException e) {
                 log.warn(String.format("table disappeared during listing operation: %s", e.getMessage()));
@@ -179,6 +219,26 @@ public abstract class IcebergAbstractMetadata
                 .setComment(column.getComment())
                 .setHidden(false)
                 .build();
+    }
+
+    @Override
+    public Map<String, ColumnHandle> getColumnHandles(ConnectorSession session, ConnectorTableHandle tableHandle)
+    {
+        IcebergTableHandle icebergHandle = (IcebergTableHandle) tableHandle;
+
+        Schema schema;
+
+        Table icebergTable = getIcebergTable(session, icebergHandle.getSchemaTableName());
+        if (icebergHandle.getTableType() == CHANGELOG) {
+            String primaryKeyColumn = IcebergTableProperties.getSampleTablePrimaryKey((Map) icebergTable.properties());
+            schema = ChangelogUtil.changelogTableSchema(getPrimaryKeyType(icebergTable, primaryKeyColumn));
+        }
+        else {
+            schema = icebergTable.schema();
+        }
+
+        return getColumns(schema, typeManager).stream()
+                .collect(toImmutableMap(IcebergColumnHandle::getName, identity()));
     }
 
     @Override

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergAbstractMetadata.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergAbstractMetadata.java
@@ -165,6 +165,9 @@ public abstract class IcebergAbstractMetadata
     private ConnectorTableMetadata getTableMetaWithType(ConnectorSession session, SchemaTableName table)
     {
         IcebergTableName itn = IcebergTableName.from(table.getTableName());
+        if (itn.isSystemTable()) {
+            throw new TableNotFoundException(table);
+        }
         ConnectorTableMetadata tableMeta = getTableMetadata(session, table);
         if (itn.getTableType() == CHANGELOG) {
             String primaryKeyColumn = IcebergTableProperties.getSampleTablePrimaryKey(tableMeta.getProperties());

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergHiveMetadata.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergHiveMetadata.java
@@ -149,7 +149,7 @@ public class IcebergHiveMetadata
     private Optional<SystemTable> getRawSystemTable(ConnectorSession session, SchemaTableName tableName)
     {
         IcebergTableName name = IcebergTableName.from(tableName.getTableName());
-        if (name.getTableType() == DATA) {
+        if (name.getTableType() == DATA || name.getTableType() == SAMPLES || name.getTableType() == CHANGELOG) {
             return Optional.empty();
         }
 

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergHiveMetadata.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergHiveMetadata.java
@@ -64,13 +64,11 @@ import static com.facebook.presto.iceberg.IcebergTableProperties.getFileFormat;
 import static com.facebook.presto.iceberg.IcebergTableProperties.getFormatVersion;
 import static com.facebook.presto.iceberg.IcebergTableProperties.getPartitioning;
 import static com.facebook.presto.iceberg.IcebergTableProperties.getTableLocation;
-import static com.facebook.presto.iceberg.IcebergUtil.createMetadataProperties;
-import static com.facebook.presto.iceberg.IcebergUtil.getColumnMetadatas;
 import static com.facebook.presto.iceberg.IcebergUtil.getColumns;
 import static com.facebook.presto.iceberg.IcebergUtil.getHiveIcebergTable;
-import static com.facebook.presto.iceberg.IcebergUtil.getTableComment;
 import static com.facebook.presto.iceberg.IcebergUtil.isIcebergTable;
 import static com.facebook.presto.iceberg.PartitionFields.parsePartitionFields;
+import static com.facebook.presto.iceberg.TableType.CHANGELOG;
 import static com.facebook.presto.iceberg.TableType.DATA;
 import static com.facebook.presto.iceberg.TableType.SAMPLES;
 import static com.facebook.presto.iceberg.TypeConverter.toIcebergType;
@@ -80,9 +78,7 @@ import static com.facebook.presto.spi.StandardErrorCode.NOT_SUPPORTED;
 import static com.facebook.presto.spi.StandardErrorCode.SCHEMA_NOT_EMPTY;
 import static com.facebook.presto.spi.security.PrincipalType.USER;
 import static com.google.common.base.Verify.verify;
-import static com.google.common.collect.ImmutableMap.toImmutableMap;
 import static java.util.Objects.requireNonNull;
-import static java.util.function.Function.identity;
 import static java.util.stream.Collectors.toList;
 import static org.apache.iceberg.TableMetadata.newTableMetadata;
 import static org.apache.iceberg.TableProperties.DEFAULT_FILE_FORMAT;
@@ -97,7 +93,6 @@ public class IcebergHiveMetadata
 {
     private static final Logger LOG = Logger.get(IcebergHiveMetadata.class);
     private final ExtendedHiveMetastore metastore;
-    private final HdfsEnvironment hdfsEnvironment;
 
     public IcebergHiveMetadata(
             ExtendedHiveMetastore metastore,
@@ -105,9 +100,8 @@ public class IcebergHiveMetadata
             TypeManager typeManager,
             JsonCodec<CommitTaskData> commitTaskCodec)
     {
-        super(typeManager, commitTaskCodec);
+        super(typeManager, commitTaskCodec, hdfsEnvironment);
         this.metastore = requireNonNull(metastore, "metastore is null");
-        this.hdfsEnvironment = requireNonNull(hdfsEnvironment, "hdfsEnvironment is null");
     }
 
     @Override
@@ -121,7 +115,7 @@ public class IcebergHiveMetadata
     public IcebergTableHandle getTableHandle(ConnectorSession session, SchemaTableName tableName)
     {
         IcebergTableName name = IcebergTableName.from(tableName.getTableName());
-        verify(name.getTableType() == DATA || name.getTableType() == SAMPLES, "Wrong table type: " + name.getTableType());
+        verify(name.getTableType() == DATA || name.getTableType() == SAMPLES || name.getTableType() == CHANGELOG, "Wrong table type: " + name.getTableType());
 
         MetastoreContext metastoreContext = new MetastoreContext(session.getIdentity(), session.getQueryId(), session.getClientInfo(), session.getSource(), Optional.empty(), false, HiveColumnConverterProvider.DEFAULT_COLUMN_CONVERTER_PROVIDER);
         Optional<Table> hiveTable = metastore.getTable(metastoreContext, tableName.getSchemaName(), name.getTableName());
@@ -180,15 +174,6 @@ public class IcebergHiveMetadata
                 .stream()
                 .map(table -> new SchemaTableName(schemaName.get(), table))
                 .collect(toList());
-    }
-
-    @Override
-    public Map<String, ColumnHandle> getColumnHandles(ConnectorSession session, ConnectorTableHandle tableHandle)
-    {
-        IcebergTableHandle table = (IcebergTableHandle) tableHandle;
-        org.apache.iceberg.Table icebergTable = getHiveIcebergTable(metastore, hdfsEnvironment, session, table.getSchemaTableName());
-        return getColumns(icebergTable.schema(), typeManager).stream()
-                .collect(toImmutableMap(IcebergColumnHandle::getName, identity()));
     }
 
     @Override
@@ -367,17 +352,14 @@ public class IcebergHiveMetadata
     }
 
     @Override
-    protected ConnectorTableMetadata getTableMetadata(ConnectorSession session, SchemaTableName table)
+    protected org.apache.iceberg.Table getIcebergTable(ConnectorSession session, SchemaTableName table)
     {
         MetastoreContext metastoreContext = new MetastoreContext(session.getIdentity(), session.getQueryId(), session.getClientInfo(), session.getSource(), Optional.empty(), false, HiveColumnConverterProvider.DEFAULT_COLUMN_CONVERTER_PROVIDER);
         if (!metastore.getTable(metastoreContext, table.getSchemaName(), table.getTableName()).isPresent()) {
             throw new TableNotFoundException(table);
         }
 
-        org.apache.iceberg.Table icebergTable = getHiveIcebergTable(metastore, hdfsEnvironment, session, table);
-        List<ColumnMetadata> columns = getColumnMetadatas(icebergTable, typeManager);
-
-        return new ConnectorTableMetadata(table, columns, createMetadataProperties(icebergTable), getTableComment(icebergTable));
+        return getHiveIcebergTable(metastore, hdfsEnvironment, session, table);
     }
 
     public ExtendedHiveMetastore getMetastore()

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergModule.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergModule.java
@@ -163,6 +163,7 @@ public class IcebergModule
         procedures.addBinding().toProvider(RollbackToSnapshotProcedure.class).in(Scopes.SINGLETON);
         procedures.addBinding().toProvider(CreateSampleTableProcedure.class).in(Scopes.SINGLETON);
         procedures.addBinding().toProvider(DeleteSampleTableProcedure.class).in(Scopes.SINGLETON);
+        procedures.addBinding().toProvider(SetTablePropertyProcedure.class).in(Scopes.SINGLETON);
 
         // for orc
         binder.bind(EncryptionLibrary.class).annotatedWith(HiveDwrfEncryptionProvider.ForCryptoService.class).to(UnsupportedEncryptionLibrary.class).in(Scopes.SINGLETON);

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergNativeMetadata.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergNativeMetadata.java
@@ -57,13 +57,11 @@ import static com.facebook.presto.iceberg.IcebergErrorCode.ICEBERG_INVALID_SNAPS
 import static com.facebook.presto.iceberg.IcebergTableProperties.getFileFormat;
 import static com.facebook.presto.iceberg.IcebergTableProperties.getFormatVersion;
 import static com.facebook.presto.iceberg.IcebergTableProperties.getPartitioning;
-import static com.facebook.presto.iceberg.IcebergUtil.createMetadataProperties;
-import static com.facebook.presto.iceberg.IcebergUtil.getColumnMetadatas;
 import static com.facebook.presto.iceberg.IcebergUtil.getColumns;
 import static com.facebook.presto.iceberg.IcebergUtil.getNativeIcebergTable;
-import static com.facebook.presto.iceberg.IcebergUtil.getTableComment;
 import static com.facebook.presto.iceberg.IcebergUtil.resolveSnapshotIdByName;
 import static com.facebook.presto.iceberg.PartitionFields.parsePartitionFields;
+import static com.facebook.presto.iceberg.TableType.CHANGELOG;
 import static com.facebook.presto.iceberg.TableType.DATA;
 import static com.facebook.presto.iceberg.TableType.SAMPLES;
 import static com.facebook.presto.iceberg.TypeConverter.toIcebergType;
@@ -72,10 +70,8 @@ import static com.facebook.presto.iceberg.util.IcebergPrestoModelConverters.toIc
 import static com.facebook.presto.spi.StandardErrorCode.NOT_SUPPORTED;
 import static com.facebook.presto.spi.StandardErrorCode.SCHEMA_NOT_EMPTY;
 import static com.google.common.base.Verify.verify;
-import static com.google.common.collect.ImmutableMap.toImmutableMap;
 import static java.lang.String.format;
 import static java.util.Objects.requireNonNull;
-import static java.util.function.Function.identity;
 import static java.util.stream.Collectors.toList;
 import static java.util.stream.Collectors.toMap;
 import static org.apache.iceberg.TableProperties.DEFAULT_FILE_FORMAT;
@@ -90,7 +86,6 @@ public class IcebergNativeMetadata
 
     private final IcebergResourceFactory resourceFactory;
     private final CatalogType catalogType;
-    private final HdfsEnvironment hdfsEnvironment;
 
     public IcebergNativeMetadata(
             IcebergResourceFactory resourceFactory,
@@ -99,10 +94,9 @@ public class IcebergNativeMetadata
             JsonCodec<CommitTaskData> commitTaskCodec,
             CatalogType catalogType)
     {
-        super(typeManager, commitTaskCodec);
+        super(typeManager, commitTaskCodec, hdfsEnvironment);
         this.resourceFactory = requireNonNull(resourceFactory, "resourceFactory is null");
         this.catalogType = requireNonNull(catalogType, "catalogType is null");
-        this.hdfsEnvironment = requireNonNull(hdfsEnvironment, "hdfsEnvironment is null");
     }
 
     @Override
@@ -119,7 +113,7 @@ public class IcebergNativeMetadata
     public IcebergTableHandle getTableHandle(ConnectorSession session, SchemaTableName tableName)
     {
         IcebergTableName name = IcebergTableName.from(tableName.getTableName());
-        verify(name.getTableType() == DATA || name.getTableType() == SAMPLES, "Wrong table type: " + name.getTableType());
+        verify(name.getTableType() == DATA || name.getTableType() == SAMPLES || name.getTableType() == CHANGELOG, "Wrong table type: " + name.getTableType());
         TableIdentifier tableIdentifier = toIcebergTableIdentifier(tableName.getSchemaName(), name.getTableName());
 
         Table table;
@@ -179,27 +173,6 @@ public class IcebergNativeMetadata
                 .stream()
                 .map(IcebergPrestoModelConverters::toPrestoSchemaTableName)
                 .collect(toList());
-    }
-
-    @Override
-    public Map<String, ColumnHandle> getColumnHandles(ConnectorSession session, ConnectorTableHandle tableHandle)
-    {
-        IcebergTableHandle table = (IcebergTableHandle) tableHandle;
-        Table icebergTable = getNativeIcebergTable(resourceFactory, session, table.getSchemaTableName());
-        return getColumns(icebergTable.schema(), typeManager).stream()
-                .collect(toImmutableMap(IcebergColumnHandle::getName, identity()));
-    }
-
-    @Override
-    public ColumnMetadata getColumnMetadata(ConnectorSession session, ConnectorTableHandle tableHandle, ColumnHandle columnHandle)
-    {
-        IcebergColumnHandle column = (IcebergColumnHandle) columnHandle;
-        return ColumnMetadata.builder()
-                .setName(column.getName())
-                .setType(column.getType())
-                .setComment(column.getComment())
-                .setHidden(false)
-                .build();
     }
 
     @Override
@@ -320,19 +293,14 @@ public class IcebergNativeMetadata
     }
 
     @Override
-    protected ConnectorTableMetadata getTableMetadata(ConnectorSession session, SchemaTableName table)
+    protected Table getIcebergTable(ConnectorSession session, SchemaTableName table)
     {
-        Table icebergTable;
         try {
-            icebergTable = getNativeIcebergTable(resourceFactory, session, table);
+            return getNativeIcebergTable(resourceFactory, session, table);
         }
         catch (NoSuchTableException e) {
             throw new TableNotFoundException(table);
         }
-
-        List<ColumnMetadata> columns = getColumnMetadatas(icebergTable, typeManager);
-
-        return new ConnectorTableMetadata(table, columns, createMetadataProperties(icebergTable), getTableComment(icebergTable));
     }
 
     @Override

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergNativeMetadata.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergNativeMetadata.java
@@ -140,7 +140,7 @@ public class IcebergNativeMetadata
     public Optional<SystemTable> getSystemTable(ConnectorSession session, SchemaTableName tableName)
     {
         IcebergTableName name = IcebergTableName.from(tableName.getTableName());
-        if (name.getTableType() == DATA) {
+        if (name.getTableType() == DATA || name.getTableType() == SAMPLES || name.getTableType() == CHANGELOG) {
             return Optional.empty();
         }
 

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergSplit.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergSplit.java
@@ -13,6 +13,7 @@
  */
 package com.facebook.presto.iceberg;
 
+import com.facebook.presto.iceberg.changelog.ChangelogSplitInfo;
 import com.facebook.presto.spi.ConnectorSplit;
 import com.facebook.presto.spi.HostAddress;
 import com.facebook.presto.spi.NodeProvider;
@@ -27,6 +28,7 @@ import org.apache.iceberg.FileFormat;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 
 import static com.facebook.presto.spi.schedule.NodeSelectionStrategy.SOFT_AFFINITY;
 import static com.google.common.base.MoreObjects.toStringHelper;
@@ -43,6 +45,7 @@ public class IcebergSplit
     private final Map<Integer, String> partitionKeys;
     private final NodeSelectionStrategy nodeSelectionStrategy;
     private final SplitWeight splitWeight;
+    private final Optional<ChangelogSplitInfo> changelogSplitInfo;
 
     @JsonCreator
     public IcebergSplit(
@@ -53,7 +56,8 @@ public class IcebergSplit
             @JsonProperty("addresses") List<HostAddress> addresses,
             @JsonProperty("partitionKeys") Map<Integer, String> partitionKeys,
             @JsonProperty("nodeSelectionStrategy") NodeSelectionStrategy nodeSelectionStrategy,
-            @JsonProperty("splitWeight") SplitWeight splitWeight)
+            @JsonProperty("splitWeight") SplitWeight splitWeight,
+            @JsonProperty("changelogSplitInfo") Optional<ChangelogSplitInfo> changelogSplitInfo)
     {
         requireNonNull(nodeSelectionStrategy, "nodeSelectionStrategy is null");
         this.path = requireNonNull(path, "path is null");
@@ -64,6 +68,7 @@ public class IcebergSplit
         this.partitionKeys = Collections.unmodifiableMap(requireNonNull(partitionKeys, "partitionKeys is null"));
         this.nodeSelectionStrategy = nodeSelectionStrategy;
         this.splitWeight = requireNonNull(splitWeight, "splitWeight is null");
+        this.changelogSplitInfo = requireNonNull(changelogSplitInfo, "changelogSplitInfo is null");
     }
 
     @JsonProperty
@@ -108,6 +113,7 @@ public class IcebergSplit
     {
         return nodeSelectionStrategy;
     }
+
     @Override
     public List<HostAddress> getPreferredNodes(NodeProvider nodeProvider)
     {
@@ -124,6 +130,12 @@ public class IcebergSplit
         return splitWeight;
     }
 
+    @JsonProperty
+    public Optional<ChangelogSplitInfo> getChangelogSplitInfo()
+    {
+        return changelogSplitInfo;
+    }
+
     @Override
     public Object getInfo()
     {
@@ -133,6 +145,7 @@ public class IcebergSplit
                 .put("length", length)
                 .put("nodeSelectionStrategy", nodeSelectionStrategy)
                 .put("splitWeight", splitWeight)
+                .put("changelogSplitInfo", changelogSplitInfo)
                 .build();
     }
 
@@ -145,6 +158,7 @@ public class IcebergSplit
                 .addValue(length)
                 .addValue(nodeSelectionStrategy)
                 .addValue(splitWeight)
+                .addValue(changelogSplitInfo)
                 .toString();
     }
 }

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergSplitManager.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergSplitManager.java
@@ -13,8 +13,10 @@
  */
 package com.facebook.presto.iceberg;
 
+import com.facebook.presto.common.type.TypeManager;
 import com.facebook.presto.hive.HdfsEnvironment;
 import com.facebook.presto.hive.metastore.ExtendedHiveMetastore;
+import com.facebook.presto.iceberg.changelog.ChangelogSplitSource;
 import com.facebook.presto.iceberg.samples.SampleUtil;
 import com.facebook.presto.spi.ConnectorSession;
 import com.facebook.presto.spi.ConnectorSplitSource;
@@ -23,6 +25,7 @@ import com.facebook.presto.spi.FixedSplitSource;
 import com.facebook.presto.spi.connector.ConnectorSplitManager;
 import com.facebook.presto.spi.connector.ConnectorTransactionHandle;
 import com.google.common.collect.ImmutableList;
+import org.apache.iceberg.IncrementalChangelogScan;
 import org.apache.iceberg.Table;
 import org.apache.iceberg.TableScan;
 import org.apache.iceberg.util.TableScanUtil;
@@ -35,6 +38,7 @@ import static com.facebook.presto.iceberg.ExpressionConverter.toIcebergExpressio
 import static com.facebook.presto.iceberg.IcebergSessionProperties.getMinimumAssignedSplitWeight;
 import static com.facebook.presto.iceberg.IcebergUtil.getHiveIcebergTable;
 import static com.facebook.presto.iceberg.IcebergUtil.getNativeIcebergTable;
+import static com.facebook.presto.iceberg.TableType.CHANGELOG;
 import static java.util.Objects.requireNonNull;
 
 public class IcebergSplitManager
@@ -44,12 +48,14 @@ public class IcebergSplitManager
     private final HdfsEnvironment hdfsEnvironment;
     private final IcebergResourceFactory resourceFactory;
     private final CatalogType catalogType;
+    private final TypeManager typeManager;
 
     @Inject
     public IcebergSplitManager(
             IcebergConfig config,
             IcebergResourceFactory resourceFactory,
             IcebergTransactionManager transactionManager,
+            TypeManager typeManager,
             HdfsEnvironment hdfsEnvironment)
     {
         this.transactionManager = requireNonNull(transactionManager, "transactionManager is null");
@@ -57,6 +63,7 @@ public class IcebergSplitManager
         this.resourceFactory = requireNonNull(resourceFactory, "resourceFactory is null");
         requireNonNull(config, "config is null");
         this.catalogType = config.getCatalogType();
+        this.typeManager = requireNonNull(typeManager, "typeManager is null");
     }
 
     @Override
@@ -85,17 +92,25 @@ public class IcebergSplitManager
             icebergTable = SampleUtil.getSampleTableFromActual(icebergTable, table.getSchemaName(), hdfsEnvironment, session);
         }
 
-        TableScan tableScan = icebergTable.newScan()
-                .filter(toIcebergExpression(table.getPredicate()))
-                .useSnapshot(table.getSnapshotId().get());
+        if (table.getTableType() == CHANGELOG) {
+            // TODO change this to calculate the correct id to scan from.
+            // this change only reads the diff between the current and immediate parent snapshot.
+            IncrementalChangelogScan scan = icebergTable.newIncrementalChangelogScan().fromSnapshotExclusive(icebergTable.currentSnapshot().parentId());
+            return new ChangelogSplitSource(session, typeManager, icebergTable, scan, scan.targetSplitSize());
+        }
+        else {
+            TableScan tableScan = icebergTable.newScan()
+                    .filter(toIcebergExpression(table.getPredicate()))
+                    .useSnapshot(table.getSnapshotId().get());
 
-        // TODO Use residual. Right now there is no way to propagate residual to presto but at least we can
-        //      propagate it at split level so the parquet pushdown can leverage it.
-        IcebergSplitSource splitSource = new IcebergSplitSource(
-                session,
-                tableScan,
-                TableScanUtil.splitFiles(tableScan.planFiles(), tableScan.targetSplitSize()),
-                getMinimumAssignedSplitWeight(session));
-        return splitSource;
+            // TODO Use residual. Right now there is no way to propagate residual to presto but at least we can
+            //      propagate it at split level so the parquet pushdown can leverage it.
+            IcebergSplitSource splitSource = new IcebergSplitSource(
+                    session,
+                    tableScan,
+                    TableScanUtil.splitFiles(tableScan.planFiles(), tableScan.targetSplitSize()),
+                    getMinimumAssignedSplitWeight(session));
+            return splitSource;
+        }
     }
 }

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergSplitManager.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergSplitManager.java
@@ -95,7 +95,9 @@ public class IcebergSplitManager
         if (table.getTableType() == CHANGELOG) {
             // TODO change this to calculate the correct id to scan from.
             // this change only reads the diff between the current and immediate parent snapshot.
-            IncrementalChangelogScan scan = icebergTable.newIncrementalChangelogScan().fromSnapshotExclusive(icebergTable.currentSnapshot().parentId());
+            long fromSnap = Long.parseLong(icebergTable.properties().get(IcebergTableProperties.SAMPLE_TABLE_LAST_SNAPSHOT));
+            IncrementalChangelogScan scan = icebergTable.newIncrementalChangelogScan()
+                    .fromSnapshotExclusive(fromSnap);
             return new ChangelogSplitSource(session, typeManager, icebergTable, scan, scan.targetSplitSize());
         }
         else {

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergTableName.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergTableName.java
@@ -14,15 +14,20 @@
 package com.facebook.presto.iceberg;
 
 import com.facebook.presto.spi.PrestoException;
+import com.google.common.collect.Sets;
 
 import java.util.Optional;
+import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 import static com.facebook.presto.iceberg.TableType.DATA;
 import static com.facebook.presto.iceberg.TableType.FILES;
+import static com.facebook.presto.iceberg.TableType.HISTORY;
 import static com.facebook.presto.iceberg.TableType.MANIFESTS;
 import static com.facebook.presto.iceberg.TableType.PARTITIONS;
+import static com.facebook.presto.iceberg.TableType.PROPERTIES;
+import static com.facebook.presto.iceberg.TableType.SNAPSHOTS;
 import static com.facebook.presto.spi.StandardErrorCode.NOT_SUPPORTED;
 import static java.lang.Long.parseLong;
 import static java.lang.String.format;
@@ -40,6 +45,8 @@ public class IcebergTableName
     private final TableType tableType;
     private final Optional<Long> snapshotId;
 
+    private static final Set<TableType> SYSTEM_TABLES = Sets.immutableEnumSet(FILES, MANIFESTS, PARTITIONS, HISTORY, SNAPSHOTS, PROPERTIES);
+
     public IcebergTableName(String tableName, TableType tableType, Optional<Long> snapshotId)
     {
         this.tableName = requireNonNull(tableName, "tableName is null");
@@ -55,6 +62,11 @@ public class IcebergTableName
     public TableType getTableType()
     {
         return tableType;
+    }
+
+    public boolean isSystemTable()
+    {
+        return SYSTEM_TABLES.contains(tableType);
     }
 
     public Optional<Long> getSnapshotId()

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergTableProperties.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergTableProperties.java
@@ -26,6 +26,7 @@ import java.util.Map;
 
 import static com.facebook.presto.common.type.VarcharType.VARCHAR;
 import static com.facebook.presto.common.type.VarcharType.createUnboundedVarcharType;
+import static com.facebook.presto.spi.session.PropertyMetadata.longProperty;
 import static com.facebook.presto.spi.session.PropertyMetadata.stringProperty;
 import static com.google.common.collect.ImmutableList.toImmutableList;
 import static java.util.Locale.ENGLISH;
@@ -36,6 +37,9 @@ public class IcebergTableProperties
     public static final String PARTITIONING_PROPERTY = "partitioning";
     public static final String LOCATION_PROPERTY = "location";
     public static final String FORMAT_VERSION = "format_version";
+
+    public static final String SAMPLE_TABLE_LAST_SNAPSHOT = "sample.last_snapshot_id";
+    public static final String SAMPLE_TABLE_PRIMARY_KEY = "sample.primary_key";
 
     private final List<PropertyMetadata<?>> tableProperties;
 
@@ -73,6 +77,16 @@ public class IcebergTableProperties
                         "Format version for the table",
                         null,
                         false))
+                .add(longProperty(
+                        SAMPLE_TABLE_LAST_SNAPSHOT,
+                        "the last snapshot id of the table for which this sample was built",
+                        null,
+                        false))
+                .add(stringProperty(
+                        SAMPLE_TABLE_PRIMARY_KEY,
+                        "the primary key used to update sample rows",
+                        null,
+                        false))
                 .build();
     }
 
@@ -101,5 +115,15 @@ public class IcebergTableProperties
     public static String getFormatVersion(Map<String, Object> tableProperties)
     {
         return (String) tableProperties.get(FORMAT_VERSION);
+    }
+
+    public static long getSampleTableLastSnapshot(Map<String, Object> tableProperties)
+    {
+        return (long) tableProperties.get(SAMPLE_TABLE_LAST_SNAPSHOT);
+    }
+
+    public static String getSampleTablePrimaryKey(Map<String, Object> tableProperties)
+    {
+        return (String) tableProperties.get(SAMPLE_TABLE_PRIMARY_KEY);
     }
 }

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergUtil.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergUtil.java
@@ -27,18 +27,25 @@ import com.facebook.presto.spi.PrestoException;
 import com.facebook.presto.spi.SchemaTableName;
 import com.google.common.collect.ImmutableMap;
 import org.apache.iceberg.BaseTable;
+import org.apache.iceberg.ContentScanTask;
+import org.apache.iceberg.DataFile;
 import org.apache.iceberg.FileFormat;
 import org.apache.iceberg.HistoryEntry;
 import org.apache.iceberg.PartitionField;
 import org.apache.iceberg.PartitionSpec;
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.Snapshot;
+import org.apache.iceberg.StructLike;
 import org.apache.iceberg.Table;
 import org.apache.iceberg.TableOperations;
 import org.apache.iceberg.TableScan;
 import org.apache.iceberg.expressions.Expression;
 import org.apache.iceberg.io.LocationProvider;
+import org.apache.iceberg.types.Type;
 
+import java.nio.ByteBuffer;
+import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -50,6 +57,8 @@ import static com.facebook.presto.iceberg.IcebergErrorCode.ICEBERG_INVALID_SNAPS
 import static com.facebook.presto.iceberg.IcebergTableProperties.FILE_FORMAT_PROPERTY;
 import static com.facebook.presto.iceberg.IcebergTableProperties.FORMAT_VERSION;
 import static com.facebook.presto.iceberg.IcebergTableProperties.PARTITIONING_PROPERTY;
+import static com.facebook.presto.iceberg.IcebergTableProperties.SAMPLE_TABLE_LAST_SNAPSHOT;
+import static com.facebook.presto.iceberg.IcebergTableProperties.SAMPLE_TABLE_PRIMARY_KEY;
 import static com.facebook.presto.iceberg.PartitionFields.toPartitionFields;
 import static com.facebook.presto.iceberg.TypeConverter.toPrestoType;
 import static com.facebook.presto.iceberg.util.IcebergPrestoModelConverters.toIcebergTableIdentifier;
@@ -58,12 +67,15 @@ import static com.google.common.collect.ImmutableList.toImmutableList;
 import static com.google.common.collect.Lists.reverse;
 import static com.google.common.collect.Streams.stream;
 import static java.lang.String.format;
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.apache.iceberg.BaseMetastoreTableOperations.ICEBERG_TABLE_TYPE_VALUE;
 import static org.apache.iceberg.BaseMetastoreTableOperations.TABLE_TYPE_PROP;
 import static org.apache.iceberg.LocationProviders.locationsFor;
 import static org.apache.iceberg.TableProperties.DEFAULT_FILE_FORMAT;
 import static org.apache.iceberg.TableProperties.DEFAULT_FILE_FORMAT_DEFAULT;
 import static org.apache.iceberg.TableProperties.WRITE_LOCATION_PROVIDER_IMPL;
+import static org.apache.iceberg.types.Type.TypeID.BINARY;
+import static org.apache.iceberg.types.Type.TypeID.FIXED;
 
 public final class IcebergUtil
 {
@@ -175,6 +187,12 @@ public final class IcebergUtil
         if (!icebergTable.spec().fields().isEmpty()) {
             properties.put(PARTITIONING_PROPERTY, toPartitionFields(icebergTable.spec()));
         }
+        if (icebergTable.properties().get(SAMPLE_TABLE_LAST_SNAPSHOT) != null) {
+            properties.put(SAMPLE_TABLE_LAST_SNAPSHOT, Long.parseLong(icebergTable.properties().get(SAMPLE_TABLE_LAST_SNAPSHOT)));
+        }
+        if (icebergTable.properties().get(SAMPLE_TABLE_PRIMARY_KEY) != null) {
+            properties.put(SAMPLE_TABLE_PRIMARY_KEY, icebergTable.properties().get(SAMPLE_TABLE_PRIMARY_KEY));
+        }
 
         return properties.build();
     }
@@ -219,5 +237,37 @@ public final class IcebergUtil
                     " as a location provider. Writing to Iceberg tables with custom location provider is not supported.");
         }
         return locationsFor(tableLocation, storageProperties);
+    }
+
+    public static Map<Integer, String> getPartitionKeys(ContentScanTask<DataFile> scanTask)
+    {
+        StructLike partition = scanTask.file().partition();
+        PartitionSpec spec = scanTask.spec();
+        Map<PartitionField, Integer> fieldToIndex = getIdentityPartitions(spec);
+        Map<Integer, String> partitionKeys = new HashMap<>();
+
+        fieldToIndex.forEach((field, index) -> {
+            int id = field.sourceId();
+            Type type = spec.schema().findType(id);
+            Class<?> javaClass = type.typeId().javaClass();
+            Object value = partition.get(index, javaClass);
+
+            if (value == null) {
+                partitionKeys.put(id, null);
+            }
+            else {
+                String partitionValue;
+                if (type.typeId() == FIXED || type.typeId() == BINARY) {
+                    // this is safe because Iceberg PartitionData directly wraps the byte array
+                    partitionValue = new String(((ByteBuffer) value).array(), UTF_8);
+                }
+                else {
+                    partitionValue = value.toString();
+                }
+                partitionKeys.put(id, partitionValue);
+            }
+        });
+
+        return Collections.unmodifiableMap(partitionKeys);
     }
 }

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/TableStatisticsMaker.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/TableStatisticsMaker.java
@@ -184,7 +184,11 @@ public class TableStatisticsMaker
             catch (IllegalArgumentException | IllegalStateException e) {
                 // no snapshot exists before this time, use the first version of the sample table after the timestamp
                 try {
-                    return Optional.of(SnapshotUtil.oldestAncestorAfter(sampleTable, actualSnap.timestampMillis()).snapshotId());
+                    Snapshot nextSnapshot = SnapshotUtil.oldestAncestorAfter(sampleTable, actualSnap.timestampMillis());
+                    if (nextSnapshot != null) {
+                        return Optional.of(nextSnapshot.snapshotId());
+                    }
+                    return Optional.empty();
                 }
                 catch (IllegalArgumentException | IllegalStateException e2) {
                     LOG.warn("no sample table snapshots found before or after " + actualSnap.timestampMillis() + ". Did you create the samples table?", e);

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/TableType.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/TableType.java
@@ -23,4 +23,5 @@ public enum TableType
     FILES,
     PROPERTIES,
     SAMPLES,
+    CHANGELOG
 }

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/changelog/ChangelogPageSource.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/changelog/ChangelogPageSource.java
@@ -1,0 +1,123 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.iceberg.changelog;
+
+import com.facebook.presto.common.Page;
+import com.facebook.presto.common.block.Block;
+import com.facebook.presto.common.block.RunLengthEncodedBlock;
+import com.facebook.presto.iceberg.IcebergColumnHandle;
+import com.facebook.presto.spi.ConnectorPageSource;
+import com.facebook.presto.spi.ConnectorSplit;
+import io.airlift.slice.Slices;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.stream.IntStream;
+
+import static com.facebook.presto.common.type.BigintType.BIGINT;
+import static com.facebook.presto.common.type.VarcharType.VARCHAR;
+import static java.util.Objects.requireNonNull;
+
+/**
+ * This is a page source which provides pages for the Changelog of an iceberg
+ * table.
+ * <br>
+ * The schema of the changelog table is always fixed to have the following columns:
+ *
+ * <ul>
+ *     <li>operation type (varchar) - a string representation of an enum value from {@link org.apache.iceberg.ChangelogOperation}</li>
+ *     <li>ordinal (int) - the order in which the change i applied relative to all other changes in the log</li>
+ *     <li>primary key (T) - this column is the type and value of the primary key that identifies the row</li>
+ *     <li>snapshot ID (long) - the snapshot id which this change belongs</li>
+ *     <li>data (row) - a column containing the data corresponding to this change</li>
+ * </ul>
+ */
+public class ChangelogPageSource
+        implements ConnectorPageSource
+{
+    private final ConnectorPageSource delegate;
+    private final ConnectorSplit split;
+    private final ChangelogSplitInfo changelogSplitInfo;
+    private final List<IcebergColumnHandle> columns;
+    private final int primaryKeyIndex;
+
+    public ChangelogPageSource(ConnectorPageSource delegate, ChangelogSplitInfo changelogSplitInfo, ConnectorSplit split, List<IcebergColumnHandle> columns)
+    {
+        this.delegate = requireNonNull(delegate, "delegate is null");
+        this.split = requireNonNull(split, "split is null");
+        this.changelogSplitInfo = requireNonNull(changelogSplitInfo, "changelogSplitInfo is null");
+        this.columns = requireNonNull(columns, "columns is null");
+        this.primaryKeyIndex = IntStream.range(0, columns.size())
+                .filter(i -> columns.get(i).getName().equals(changelogSplitInfo.getPrimaryKeyColumnName())).findFirst().getAsInt();
+    }
+
+    @Override
+    public long getCompletedBytes()
+    {
+        return delegate.getCompletedBytes();
+    }
+
+    @Override
+    public long getCompletedPositions()
+    {
+        return delegate.getCompletedPositions();
+    }
+
+    @Override
+    public long getReadTimeNanos()
+    {
+        return delegate.getReadTimeNanos();
+    }
+
+    @Override
+    public boolean isFinished()
+    {
+        return delegate.isFinished();
+    }
+
+    @Override
+    public Page getNextPage()
+    {
+        // In order to produce the correct page, we have to build the blocks that
+        // make up the schema of the changelog table.
+        // First, create blocks matching the number of rows in the page
+        // then, extract the block pertaining to the primary key of the table
+        // then, combine all blocks into a single page.
+        Page delegatePage = delegate.getNextPage();
+        if (delegatePage == null) {
+            return null;
+        }
+        int columnCount = 4;
+        int rows = delegatePage.getPositionCount();
+        Block[] columns = new Block[columnCount];
+        columns[0] = RunLengthEncodedBlock.create(VARCHAR, Slices.utf8Slice(changelogSplitInfo.getOperation().toString()), rows);
+        columns[1] = RunLengthEncodedBlock.create(BIGINT, changelogSplitInfo.getChangeOrdinal(), rows);
+        columns[2] = RunLengthEncodedBlock.create(BIGINT, changelogSplitInfo.getSnapshotId(), rows);
+        columns[3] = delegatePage.getBlock(primaryKeyIndex);
+        return new Page(columns);
+    }
+
+    @Override
+    public long getSystemMemoryUsage()
+    {
+        return delegate.getSystemMemoryUsage();
+    }
+
+    @Override
+    public void close()
+            throws IOException
+    {
+        delegate.close();
+    }
+}

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/changelog/ChangelogSplitInfo.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/changelog/ChangelogSplitInfo.java
@@ -1,0 +1,90 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.iceberg.changelog;
+
+import com.facebook.presto.iceberg.IcebergColumnHandle;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import org.apache.iceberg.ChangelogOperation;
+
+import java.util.List;
+
+import static com.google.common.base.MoreObjects.toStringHelper;
+import static java.util.Objects.requireNonNull;
+
+public class ChangelogSplitInfo
+{
+    private final ChangelogOperation operation;
+    private final long changeOrdinal;
+    private final long snapshotId;
+    private final String primaryKeyColumnName;
+    private final List<IcebergColumnHandle> icebergColumns;
+
+    @JsonCreator
+    public ChangelogSplitInfo(
+            @JsonProperty("operation") ChangelogOperation operation,
+            @JsonProperty("changeOrdinal") long changeOrdinal,
+            @JsonProperty("snapshotId") long snapshotId,
+            @JsonProperty("primaryKeyColumnName") String primaryKeyColumnName,
+            @JsonProperty("icebergColumns") List<IcebergColumnHandle> icebergColumns)
+    {
+        this.operation = requireNonNull(operation, "operation is null");
+        this.changeOrdinal = changeOrdinal;
+        this.snapshotId = snapshotId;
+        this.primaryKeyColumnName = requireNonNull(primaryKeyColumnName, "primaryKeyColumnName is null");
+        this.icebergColumns = requireNonNull(icebergColumns, "icebergColumns is null");
+    }
+
+    @JsonProperty
+    public ChangelogOperation getOperation()
+    {
+        return operation;
+    }
+
+    @JsonProperty
+    public long getChangeOrdinal()
+    {
+        return changeOrdinal;
+    }
+
+    @JsonProperty
+    public long getSnapshotId()
+    {
+        return snapshotId;
+    }
+
+    @JsonProperty
+    public String getPrimaryKeyColumnName()
+    {
+        return primaryKeyColumnName;
+    }
+
+    @JsonProperty
+    public List<IcebergColumnHandle> getIcebergColumns()
+    {
+        return icebergColumns;
+    }
+
+    @Override
+    public String toString()
+    {
+        return toStringHelper(this)
+                .addValue(operation)
+                .addValue(changeOrdinal)
+                .addValue(snapshotId)
+                .addValue(primaryKeyColumnName)
+                .addValue(icebergColumns)
+                .toString();
+    }
+}

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/changelog/ChangelogSplitSource.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/changelog/ChangelogSplitSource.java
@@ -11,18 +11,28 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.facebook.presto.iceberg;
+package com.facebook.presto.iceberg.changelog;
 
+import com.facebook.presto.common.type.TypeManager;
+import com.facebook.presto.iceberg.IcebergColumnHandle;
+import com.facebook.presto.iceberg.IcebergSplit;
+import com.facebook.presto.iceberg.IcebergTableProperties;
 import com.facebook.presto.spi.ConnectorSession;
 import com.facebook.presto.spi.ConnectorSplit;
 import com.facebook.presto.spi.ConnectorSplitSource;
+import com.facebook.presto.spi.PrestoException;
 import com.facebook.presto.spi.SplitWeight;
 import com.facebook.presto.spi.connector.ConnectorPartitionHandle;
 import com.google.common.collect.ImmutableList;
 import com.google.common.io.Closer;
-import org.apache.iceberg.FileScanTask;
-import org.apache.iceberg.TableScan;
-import org.apache.iceberg.io.CloseableIterable;
+import org.apache.iceberg.AddedRowsScanTask;
+import org.apache.iceberg.ChangelogScanTask;
+import org.apache.iceberg.ContentScanTask;
+import org.apache.iceberg.DataFile;
+import org.apache.iceberg.DeletedDataFileScanTask;
+import org.apache.iceberg.DeletedRowsScanTask;
+import org.apache.iceberg.IncrementalChangelogScan;
+import org.apache.iceberg.Table;
 import org.apache.iceberg.io.CloseableIterator;
 
 import java.io.IOException;
@@ -30,58 +40,62 @@ import java.io.UncheckedIOException;
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 
+import static com.facebook.presto.iceberg.IcebergErrorCode.ICEBERG_CANNOT_OPEN_SPLIT;
 import static com.facebook.presto.iceberg.IcebergSessionProperties.getNodeSelectionStrategy;
+import static com.facebook.presto.iceberg.IcebergUtil.getColumns;
 import static com.facebook.presto.iceberg.IcebergUtil.getPartitionKeys;
 import static com.google.common.collect.Iterators.limit;
 import static java.util.Objects.requireNonNull;
 import static java.util.concurrent.CompletableFuture.completedFuture;
 
-public class IcebergSplitSource
+public class ChangelogSplitSource
         implements ConnectorSplitSource
 {
-    private CloseableIterable<FileScanTask> fileScanTaskIterable;
-    private CloseableIterator<FileScanTask> fileScanTaskIterator;
+    private CloseableIterator<ChangelogScanTask> fileScanTaskIterator;
 
-    private final TableScan tableScan;
+    private final Table table;
+    private final IncrementalChangelogScan tableScan;
     private final Closer closer = Closer.create();
     private final double minimumAssignedSplitWeight;
     private final ConnectorSession session;
+    private final List<IcebergColumnHandle> columnHandles;
 
-    public IcebergSplitSource(
+    public ChangelogSplitSource(
             ConnectorSession session,
-            TableScan tableScan,
-            CloseableIterable<FileScanTask> fileScanTaskIterable,
+            TypeManager typeManager,
+            Table table,
+            IncrementalChangelogScan tableScan,
             double minimumAssignedSplitWeight)
     {
         this.session = requireNonNull(session, "session is null");
+        this.columnHandles = getColumns(table.schema(), typeManager);
+        this.table = requireNonNull(table, "table is null");
         this.tableScan = requireNonNull(tableScan, "tableScan is null");
-        this.fileScanTaskIterable = requireNonNull(fileScanTaskIterable, "combinedScanIterable is null");
-        this.fileScanTaskIterator = fileScanTaskIterable.iterator();
         this.minimumAssignedSplitWeight = minimumAssignedSplitWeight;
-        closer.register(fileScanTaskIterable);
+        this.fileScanTaskIterator = tableScan.planFiles().iterator();
         closer.register(fileScanTaskIterator);
-    }
-
-    @Override
-    public CompletableFuture<ConnectorSplitBatch> getNextBatch(ConnectorPartitionHandle partitionHandle, int maxSize)
-    {
-        // TODO: move this to a background thread
-        List<ConnectorSplit> splits = new ArrayList<>();
-        Iterator<FileScanTask> iterator = limit(fileScanTaskIterator, maxSize);
-        while (iterator.hasNext()) {
-            FileScanTask task = iterator.next();
-            splits.add(toIcebergSplit(task));
-        }
-        return completedFuture(new ConnectorSplitBatch(splits, isFinished()));
     }
 
     @Override
     public boolean isFinished()
     {
         return !fileScanTaskIterator.hasNext();
+    }
+
+    @Override
+    public CompletableFuture<ConnectorSplitBatch> getNextBatch(ConnectorPartitionHandle partitionHandle, int maxSize)
+    {
+        List<ConnectorSplit> splits = new ArrayList<>();
+        Iterator<ChangelogScanTask> iterator = limit(fileScanTaskIterator, maxSize);
+        while (iterator.hasNext()) {
+            ChangelogScanTask task = iterator.next();
+            splits.add(toIcebergSplit(task));
+        }
+        return completedFuture(new ConnectorSplitBatch(splits, isFinished()));
     }
 
     @Override
@@ -95,13 +109,19 @@ public class IcebergSplitSource
         }
     }
 
-    private ConnectorSplit toIcebergSplit(FileScanTask task)
+    private ConnectorSplit toIcebergSplit(ChangelogScanTask task)
     {
-        // TODO: We should leverage residual expression and convert that to TupleDomain.
-        //       The predicate here is used by readers for predicate push down at reader level,
-        //       so when we do not use residual expression, we are just wasting CPU cycles
-        //       on reader side evaluating a condition that we know will always be true.
+        if (task instanceof AddedRowsScanTask || task instanceof DeletedRowsScanTask || task instanceof DeletedDataFileScanTask) {
+            ContentScanTask<DataFile> scanTask = (ContentScanTask<DataFile>) task;
+            return splitFromContentScanTask(scanTask, task);
+        }
+        else {
+            throw new PrestoException(ICEBERG_CANNOT_OPEN_SPLIT, "unsupported task type " + task.getClass().getCanonicalName());
+        }
+    }
 
+    private IcebergSplit splitFromContentScanTask(ContentScanTask<DataFile> task, ChangelogScanTask changeTask)
+    {
         return new IcebergSplit(
                 task.file().path().toString(),
                 task.start(),
@@ -111,6 +131,10 @@ public class IcebergSplitSource
                 getPartitionKeys(task),
                 getNodeSelectionStrategy(session),
                 SplitWeight.fromProportion(Math.min(Math.max((double) task.length() / tableScan.targetSplitSize(), minimumAssignedSplitWeight), 1.0)),
-                Optional.empty());
+                Optional.of(new ChangelogSplitInfo(changeTask.operation(),
+                        changeTask.changeOrdinal(),
+                        changeTask.commitSnapshotId(),
+                        IcebergTableProperties.getSampleTablePrimaryKey((Map) table.properties()),
+                        columnHandles)));
     }
 }

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/changelog/ChangelogSplitSource.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/changelog/ChangelogSplitSource.java
@@ -43,6 +43,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
+import java.util.stream.Collectors;
 
 import static com.facebook.presto.iceberg.IcebergErrorCode.ICEBERG_CANNOT_OPEN_SPLIT;
 import static com.facebook.presto.iceberg.IcebergSessionProperties.getNodeSelectionStrategy;
@@ -122,6 +123,7 @@ public class ChangelogSplitSource
 
     private IcebergSplit splitFromContentScanTask(ContentScanTask<DataFile> task, ChangelogScanTask changeTask)
     {
+        String primaryKeyColumnName = IcebergTableProperties.getSampleTablePrimaryKey((Map) table.properties());
         return new IcebergSplit(
                 task.file().path().toString(),
                 task.start(),
@@ -134,7 +136,7 @@ public class ChangelogSplitSource
                 Optional.of(new ChangelogSplitInfo(changeTask.operation(),
                         changeTask.changeOrdinal(),
                         changeTask.commitSnapshotId(),
-                        IcebergTableProperties.getSampleTablePrimaryKey((Map) table.properties()),
-                        columnHandles)));
+                        primaryKeyColumnName,
+                        columnHandles.stream().filter(x -> x.getName().equalsIgnoreCase(primaryKeyColumnName)).collect(Collectors.toList()))));
     }
 }

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/changelog/ChangelogUtil.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/changelog/ChangelogUtil.java
@@ -1,0 +1,67 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.iceberg.changelog;
+
+import com.facebook.presto.common.type.TypeManager;
+import com.facebook.presto.spi.ColumnMetadata;
+import com.facebook.presto.spi.ConnectorTableMetadata;
+import com.facebook.presto.spi.SchemaTableName;
+import com.google.common.collect.ImmutableList;
+import org.apache.iceberg.Schema;
+import org.apache.iceberg.Table;
+import org.apache.iceberg.types.Type;
+import org.apache.iceberg.types.Types;
+
+import java.util.List;
+
+import static com.facebook.presto.iceberg.TypeConverter.toIcebergType;
+import static com.facebook.presto.iceberg.TypeConverter.toPrestoType;
+
+public class ChangelogUtil
+{
+    private ChangelogUtil() {}
+
+    public static Schema changelogTableSchema(Type primaryKeyType)
+    {
+        return new Schema(
+                Types.NestedField.required(0, "operation", Types.StringType.get()),
+                Types.NestedField.required(1, "ordinal", Types.LongType.get()),
+                Types.NestedField.required(2, "snapshotId", Types.LongType.get()),
+                Types.NestedField.required(3, "primary_key", primaryKeyType));
+    }
+
+    public static ConnectorTableMetadata getChangelogTableMeta(SchemaTableName tableName, Type primaryKeyType, TypeManager typeManager)
+    {
+        return new ConnectorTableMetadata(tableName, getColumnMetadata(typeManager, primaryKeyType));
+    }
+
+    public static Type getPrimaryKeyType(Table table, String columnName)
+    {
+        return table.schema().findType(columnName);
+    }
+
+    public static Type getPrimaryKeyType(ConnectorTableMetadata table, String columnName)
+    {
+        return toIcebergType(table.getColumns().stream().filter(x -> x.getName().equals(columnName)).findFirst().get().getType());
+    }
+
+    public static List<ColumnMetadata> getColumnMetadata(TypeManager typeManager, Type primaryKeyType)
+    {
+        ImmutableList.Builder<ColumnMetadata> builder = ImmutableList.builder();
+        changelogTableSchema(primaryKeyType).columns().stream()
+                .map(x -> new ColumnMetadata(x.name(), toPrestoType(x.type(), typeManager)))
+                .forEach(builder::add);
+        return builder.build();
+    }
+}

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/changelog/ChangelogUtil.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/changelog/ChangelogUtil.java
@@ -32,13 +32,19 @@ public class ChangelogUtil
 {
     private ChangelogUtil() {}
 
+    @FunctionalInterface
+    protected interface Function2<T1, T2, R>
+    {
+        R apply(T1 arg1, T2 arg2);
+    }
+
     public static Schema changelogTableSchema(Type primaryKeyType)
     {
         return new Schema(
-                Types.NestedField.required(0, "operation", Types.StringType.get()),
-                Types.NestedField.required(1, "ordinal", Types.LongType.get()),
-                Types.NestedField.required(2, "snapshotId", Types.LongType.get()),
-                Types.NestedField.required(3, "primary_key", primaryKeyType));
+                Types.NestedField.required(1, "operation", Types.StringType.get()),
+                Types.NestedField.required(2, "ordinal", Types.LongType.get()),
+                Types.NestedField.required(3, "snapshot_id", Types.LongType.get()),
+                Types.NestedField.required(4, "primary_key", primaryKeyType));
     }
 
     public static ConnectorTableMetadata getChangelogTableMeta(SchemaTableName tableName, Type primaryKeyType, TypeManager typeManager)

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/changelog/ChangelogUtil.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/changelog/ChangelogUtil.java
@@ -13,7 +13,10 @@
  */
 package com.facebook.presto.iceberg.changelog;
 
+import com.facebook.presto.common.predicate.Domain;
+import com.facebook.presto.common.predicate.TupleDomain;
 import com.facebook.presto.common.type.TypeManager;
+import com.facebook.presto.iceberg.IcebergColumnHandle;
 import com.facebook.presto.spi.ColumnMetadata;
 import com.facebook.presto.spi.ConnectorTableMetadata;
 import com.facebook.presto.spi.SchemaTableName;
@@ -24,7 +27,10 @@ import org.apache.iceberg.types.Type;
 import org.apache.iceberg.types.Types;
 
 import java.util.List;
+import java.util.Map;
+import java.util.Optional;
 
+import static com.facebook.presto.iceberg.IcebergUtil.getColumns;
 import static com.facebook.presto.iceberg.TypeConverter.toIcebergType;
 import static com.facebook.presto.iceberg.TypeConverter.toPrestoType;
 
@@ -69,5 +75,34 @@ public class ChangelogUtil
                 .map(x -> new ColumnMetadata(x.name(), toPrestoType(x.type(), typeManager)))
                 .forEach(builder::add);
         return builder.build();
+    }
+
+    /**
+     * Converts a tuple domain with the column name "primary_key" to the same domain with a column
+     * handle corresponding to the primary key's actual column name and id.
+     * <br>
+     * If any additional filters exist which aren't columns on the actual iceberg table then they
+     * are removed from the {@link TupleDomain}
+     *
+     * @return A {@link TupleDomain} which is valid for the actual iceberg table rather than the
+     * changelog version of the table.
+     */
+    public static TupleDomain<IcebergColumnHandle> convertTupleDomain(TupleDomain<IcebergColumnHandle> tupleDomain, String primaryKeyColumnName, Table actualTable, TypeManager typeManager)
+    {
+        IcebergColumnHandle primaryKeyColumn = getColumns(actualTable.schema(), typeManager).stream()
+                .filter(x -> x.getName().equalsIgnoreCase(primaryKeyColumnName)).findFirst().get();
+        return tupleDomain.getDomains().map(x -> {
+            ImmutableList.Builder<TupleDomain.ColumnDomain<IcebergColumnHandle>> newDomains = ImmutableList.builder();
+            for (Map.Entry<IcebergColumnHandle, Domain> handle : x.entrySet()) {
+                if (handle.getKey().getName().equalsIgnoreCase(ChangelogPageSource.ChangelogSchemaColumns.PRIMARY_KEY.name())) {
+                    newDomains.add(new TupleDomain.ColumnDomain<>(primaryKeyColumn, handle.getValue()));
+                    break; // there should only be one column
+                }
+                else {
+                    return TupleDomain.<IcebergColumnHandle>all();
+                }
+            }
+            return TupleDomain.fromColumnDomains(Optional.of(newDomains.build()));
+        }).orElseGet(TupleDomain::all);
     }
 }

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/samples/SampleUtil.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/samples/SampleUtil.java
@@ -15,12 +15,8 @@ package com.facebook.presto.iceberg.samples;
 
 import com.facebook.presto.hive.HdfsContext;
 import com.facebook.presto.hive.HdfsEnvironment;
-import com.facebook.presto.hive.metastore.ExtendedHiveMetastore;
-import com.facebook.presto.iceberg.IcebergHiveMetadata;
-import com.facebook.presto.iceberg.IcebergResourceFactory;
 import com.facebook.presto.spi.ConnectorSession;
 import com.facebook.presto.spi.PrestoException;
-import com.facebook.presto.spi.SchemaTableName;
 import org.apache.hadoop.fs.Path;
 import org.apache.iceberg.Table;
 import org.apache.iceberg.catalog.TableIdentifier;
@@ -31,7 +27,6 @@ import java.util.HashMap;
 import java.util.Map;
 
 import static com.facebook.presto.iceberg.IcebergErrorCode.ICEBERG_FILESYSTEM_ERROR;
-import static com.facebook.presto.iceberg.IcebergUtil.getHiveIcebergTable;
 import static com.facebook.presto.iceberg.util.IcebergPrestoModelConverters.toIcebergTableIdentifier;
 import static org.apache.iceberg.CatalogProperties.WAREHOUSE_LOCATION;
 
@@ -40,17 +35,6 @@ public class SampleUtil
     private SampleUtil() {}
 
     public static final TableIdentifier SAMPLE_TABLE_ID = toIcebergTableIdentifier("sample", "sample-table");
-
-    public static Table getNativeTable(ConnectorSession session, IcebergResourceFactory resourceFactory, SchemaTableName table)
-    {
-        return resourceFactory.getCatalog(session).loadTable(toIcebergTableIdentifier(table.getSchemaName(), table.getTableName()));
-    }
-
-    public static Table getHiveTable(ConnectorSession session, IcebergHiveMetadata metadata, HdfsEnvironment env, SchemaTableName table)
-    {
-        ExtendedHiveMetastore metastore = metadata.getMetastore();
-        return getHiveIcebergTable(metastore, env, session, table);
-    }
 
     public static AutoCloseableCatalog getCatalogForSampleTable(Table icebergSource, String prestoSchema, HdfsEnvironment env, ConnectorSession session)
     {

--- a/presto-iceberg/src/test/java/com/facebook/presto/iceberg/TestIcebergTableChangelog.java
+++ b/presto-iceberg/src/test/java/com/facebook/presto/iceberg/TestIcebergTableChangelog.java
@@ -1,0 +1,133 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.iceberg;
+
+import com.facebook.presto.testing.QueryRunner;
+import com.facebook.presto.tests.AbstractTestQueryFramework;
+import com.google.common.collect.ImmutableMap;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import java.util.Map;
+
+import static com.facebook.presto.iceberg.IcebergQueryRunner.createIcebergQueryRunner;
+
+public class TestIcebergTableChangelog
+        extends AbstractTestQueryFramework
+{
+    @Override
+    protected QueryRunner createQueryRunner()
+            throws Exception
+    {
+        Map<String, String> properties = ImmutableMap.of("http-server.http.port", "8080");
+        return createIcebergQueryRunner(properties, ImmutableMap.of());
+    }
+
+    @Override
+    @BeforeClass
+    public void init() throws Exception
+    {
+        super.init();
+        assertQuerySucceeds("CALL iceberg.system.create_sample_table('tpch', 'orders', 'orderkey')");
+        assertQuerySucceeds("INSERT INTO \"orders\" SELECT * FROM tpch.tiny.orders TABLESAMPLE BERNOULLI(1)");
+        assertQuerySucceeds("INSERT INTO \"orders\" SELECT * FROM tpch.tiny.orders TABLESAMPLE BERNOULLI(1)");
+    }
+
+    @Test
+    public void testSchema()
+    {
+        assertQuery("SHOW COLUMNS FROM \"orders$changelog\"",
+                "VALUES" +
+                        "('operation', 'varchar', '', '')," +
+                        "('ordinal', 'bigint', '', '')," +
+                        "('snapshot_id', 'bigint', '', '')," +
+                        "('primary_key', 'bigint', '', '')");
+    }
+
+    @Test
+    public void testBasicSelect()
+    {
+        assertQuerySucceeds("SELECT * FROM \"orders$changelog\"");
+    }
+
+    @Test
+    public void testSelectPredicatePrimaryKey()
+    {
+        assertQuerySucceeds("SELECT * FROM \"orders$changelog\" WHERE primary_key > 9000");
+    }
+
+    @Test
+    public void testSelectPredicateStaticColumns()
+    {
+        assertQuerySucceeds("SELECT * FROM \"orders$changelog\" WHERE ordinal != 0");
+        assertQuerySucceeds("SELECT * FROM \"orders$changelog\" WHERE ordinal = 0");
+        assertQuerySucceeds("SELECT * FROM \"orders$changelog\" WHERE snapshot_id = 0");
+        assertQuerySucceeds("SELECT * FROM \"orders$changelog\" WHERE snapshot_id != 0");
+        assertQuerySucceeds("SELECT * FROM \"orders$changelog\" WHERE operation != 'INSERT'");
+        assertQuerySucceeds("SELECT * FROM \"orders$changelog\" WHERE operation = 'INSERT'");
+    }
+
+    @Test
+    public void testPrimaryKeyProjection()
+    {
+        assertQuerySucceeds("SELECT primary_key FROM \"orders$changelog\"");
+    }
+
+    @Test
+    public void testBasicAggregation()
+    {
+        assertQuerySucceeds("SELECT count(primary_key) FROM \"orders$changelog\"");
+    }
+
+    @Test
+    public void testStaticColumnProjections()
+    {
+        assertQuerySucceeds("SELECT operation, ordinal, snapshot_id FROM \"orders$changelog\"");
+        assertQuerySucceeds("SELECT snapshot_id, ordinal, operation FROM \"orders$changelog\"");
+        assertQuerySucceeds("SELECT ordinal, snapshot_id FROM \"orders$changelog\"");
+        assertQuerySucceeds("SELECT operation, snapshot_id FROM \"orders$changelog\"");
+        assertQuerySucceeds("SELECT snapshot_id FROM \"orders$changelog\"");
+        assertQuerySucceeds("SELECT ordinal FROM \"orders$changelog\"");
+        assertQuerySucceeds("SELECT operation FROM \"orders$changelog\"");
+    }
+
+    @Test
+    public void testCombinedColumnProjections()
+    {
+        assertQuerySucceeds("SELECT primary_key, operation FROM \"orders$changelog\"");
+        assertQuerySucceeds("SELECT primary_key, ordinal FROM \"orders$changelog\"");
+        assertQuerySucceeds("SELECT primary_key, snapshot_id FROM \"orders$changelog\"");
+    }
+
+    @Test
+    public void testJoinOnSnapshotTimestamp()
+    {
+        assertQuerySucceeds("SELECT * FROM \"orders$snapshots\"");
+        assertQuerySucceeds("SELECT snap.committed_at, change.operation, primary_key, ordinal" +
+                " FROM \"orders$snapshots\" as snap" +
+                " JOIN \"orders$changelog\" as change" +
+                " ON change.snapshot_id = snap.snapshot_id" +
+                " ORDER BY snap.committed_at asc");
+    }
+
+    @Test
+    public void testRightOuterJoinOnSamples()
+    {
+        assertQuerySucceeds("INSERT INTO \"orders$samples\" SELECT * FROM orders TABLESAMPLE BERNOULLI(1)");
+        assertQuerySucceeds("SELECT orderkey, operation, ordinal, snapshot_id" +
+                "   FROM \"orders$samples\" as sample" +
+                "   RIGHT OUTER JOIN \"orders$changelog\" as cl" +
+                "   ON cl.primary_key = sample.orderkey");
+    }
+}

--- a/presto-iceberg/src/test/java/com/facebook/presto/iceberg/TestIcebergTableSampling.java
+++ b/presto-iceberg/src/test/java/com/facebook/presto/iceberg/TestIcebergTableSampling.java
@@ -52,32 +52,36 @@ public class TestIcebergTableSampling
     @Test
     public void testCreateSampleTable()
     {
-        assertUpdate("CALL iceberg.system.create_sample_table('tpch', 'lineitem', 'orderkey')");
-        assertQuerySucceeds("SELECT count(*) FROM \"lineitem$samples\"");
+        assertQuerySucceeds("CREATE TABLE test_create_sample(i int)");
+        assertUpdate("CALL iceberg.system.create_sample_table('tpch', 'test_create_sample', 'i')");
+        assertQuerySucceeds("SELECT count(*) FROM \"test_create_sample$samples\"");
     }
 
     @Test
     public void testInsertIntoSampleTable()
     {
-        assertQuerySucceeds("CALL iceberg.system.create_sample_table('tpch', 'lineitem', 'orderkey')");
-        assertUpdate("INSERT INTO \"lineitem$samples\" SELECT * FROM tpch.lineitem LIMIT 3", 3);
+        assertQuerySucceeds("CREATE TABLE test_insert_sample(i int)");
+        assertQuerySucceeds("CALL iceberg.system.create_sample_table('tpch', 'test_insert_sample', 'i')");
+        assertUpdate("INSERT INTO \"test_insert_sample$samples\" (VALUES 1, 2, 3)", 3);
     }
 
     @Test
     public void testQuerySampleTable()
     {
-        assertQuerySucceeds("CALL iceberg.system.create_sample_table('tpch', 'lineitem', 'orderkey')");
-        assertUpdate("INSERT INTO \"lineitem$samples\" SELECT * FROM tpch.lineitem LIMIT 3", 3);
-        assertQuerySucceeds("SELECT * FROM \"lineitem$samples\"");
-        assertQuerySucceeds("SELECT count(*) FROM \"lineitem$samples\"");
+        assertQuerySucceeds("CREATE TABLE test_query_sample_table(i int)");
+        assertQuerySucceeds("CALL iceberg.system.create_sample_table('tpch', 'test_query_sample_table', 'i')");
+        assertUpdate("INSERT INTO \"test_query_sample_table$samples\" (VALUES 3, 4, 5)", 3);
+        assertQuerySucceeds("SELECT * FROM \"test_query_sample_table$samples\"");
+        assertQuerySucceeds("SELECT count(*) FROM \"test_query_sample_table$samples\"");
     }
 
     @Test
     public void testGetStatsForSampleExplicit()
     {
-        assertQuerySucceeds("CALL iceberg.system.create_sample_table('tpch', 'lineitem', 'orderkey')");
-        assertUpdate("INSERT INTO \"lineitem$samples\" SELECT * FROM tpch.lineitem LIMIT 3", 3);
-        assertQuerySucceeds("SHOW STATS FOR \"lineitem$samples\"");
+        assertQuerySucceeds("CREATE TABLE get_stats_explicit(i int)");
+        assertQuerySucceeds("CALL iceberg.system.create_sample_table('tpch', 'get_stats_explicit', 'orderkey')");
+        assertUpdate("INSERT INTO \"get_stats_explicit$samples\" (VALUES 1, 2, 3)", 3);
+        assertQuerySucceeds("SHOW STATS FOR \"get_stats_explicit$samples\"");
     }
 
     @Test
@@ -86,13 +90,11 @@ public class TestIcebergTableSampling
         Session session = Session.builder(getSession())
                 .setSystemProperty("iceberg." + IcebergSessionProperties.USE_SAMPLE_STATISTICS, "false")
                 .build();
-
-        assertQuerySucceeds("DROP TABLE IF EXISTS test");
-        assertQuerySucceeds("CREATE TABLE test(i int)");
-        assertUpdate("INSERT INTO test VALUES(1)", 1);
-        assertQuerySucceeds("CALL iceberg.system.create_sample_table('tpch', 'test', 'i')");
-        assertUpdate("INSERT INTO \"test$samples\" VALUES (2)", 1);
-        MaterializedResult r = this.computeActual(session, "SHOW STATS FOR test");
+        assertQuerySucceeds("CREATE TABLE test_stats_actual(i int)");
+        assertUpdate("INSERT INTO test_stats_actual VALUES(1)", 1);
+        assertQuerySucceeds("CALL iceberg.system.create_sample_table('tpch', 'test_stats_actual', 'i')");
+        assertUpdate("INSERT INTO \"test_stats_actual$samples\" VALUES (2)", 1);
+        MaterializedResult r = this.computeActual(session, "SHOW STATS FOR test_stats_actual");
         int max = Integer.parseInt(r.getMaterializedRows().get(0).getField(6).toString());
         int min = Integer.parseInt(r.getMaterializedRows().get(0).getField(5).toString());
         assertEquals(min, 1);
@@ -106,12 +108,11 @@ public class TestIcebergTableSampling
                 .setSystemProperty("iceberg." + IcebergSessionProperties.USE_SAMPLE_STATISTICS, "true")
                 .build();
 
-        assertQuerySucceeds("DROP TABLE IF EXISTS test");
-        assertQuerySucceeds("CREATE TABLE test(i int)");
-        assertUpdate("INSERT INTO test VALUES(1)", 1);
-        assertQuerySucceeds("CALL iceberg.system.create_sample_table('tpch', 'test', 'i')");
-        assertUpdate("INSERT INTO \"test$samples\" VALUES (2)", 1);
-        MaterializedResult r = this.computeActual(session, "SHOW STATS FOR test");
+        assertQuerySucceeds("CREATE TABLE test_stats_sample(i int)");
+        assertUpdate("INSERT INTO test_stats_sample VALUES(1)", 1);
+        assertQuerySucceeds("CALL iceberg.system.create_sample_table('tpch', 'test_stats_sample', 'i')");
+        assertUpdate("INSERT INTO \"test_stats_sample$samples\" VALUES (2)", 1);
+        MaterializedResult r = this.computeActual(session, "SHOW STATS FOR test_stats_sample");
         int max = Integer.parseInt(r.getMaterializedRows().get(0).getField(6).toString());
         int min = Integer.parseInt(r.getMaterializedRows().get(0).getField(5).toString());
         assertEquals(min, 2);
@@ -119,27 +120,26 @@ public class TestIcebergTableSampling
     }
 
     @Test
-    public void testSnapshotTableStatsUsePrev()
+    public void testSampleTableStatsUsePrev()
     {
         Session session = Session.builder(getSession())
                 .setSystemProperty("iceberg." + IcebergSessionProperties.USE_SAMPLE_STATISTICS, "true")
                 .build();
 
-        assertQuerySucceeds("DROP TABLE IF EXISTS test");
-        assertQuerySucceeds("CREATE TABLE test(i int)");
-        assertUpdate("INSERT INTO test VALUES(1)", 1);
-        assertQuerySucceeds("CALL iceberg.system.create_sample_table('tpch', 'test', 'i')");
-        assertUpdate("INSERT INTO \"test$samples\" VALUES (2)", 1);
-        assertUpdate("INSERT INTO test VALUES(2)", 1);
-        assertUpdate("INSERT INTO test VALUES(3)", 1);
-        assertUpdate("INSERT INTO test VALUES(5)", 1);
-        assertUpdate("INSERT INTO test (VALUES 5, 6, 7, 8, 9)", 5);
-        assertUpdate("INSERT INTO \"test$samples\" VALUES (3)", 1);
-        List<Long> actualSnapshots = getSnapshotIds(session, "test");
+        assertQuerySucceeds("CREATE TABLE test_stats_sample_prev(i int)");
+        assertUpdate("INSERT INTO test_stats_sample_prev VALUES(1)", 1);
+        assertQuerySucceeds("CALL iceberg.system.create_sample_table('tpch', 'test_stats_sample_prev', 'i')");
+        assertUpdate("INSERT INTO \"test_stats_sample_prev$samples\" VALUES (2)", 1);
+        assertUpdate("INSERT INTO test_stats_sample_prev VALUES(2)", 1);
+        assertUpdate("INSERT INTO test_stats_sample_prev VALUES(3)", 1);
+        assertUpdate("INSERT INTO test_stats_sample_prev VALUES(5)", 1);
+        assertUpdate("INSERT INTO test_stats_sample_prev (VALUES 5, 6, 7, 8, 9)", 5);
+        assertUpdate("INSERT INTO \"test_stats_sample_prev$samples\" VALUES (3)", 1);
+        List<Long> actualSnapshots = getSnapshotIds(session, "test_stats_sample_prev");
         List<Long> snapshotsUsingPrev = actualSnapshots.subList(0, actualSnapshots.size() - 1);
 
         for (Long snapshot : snapshotsUsingPrev) {
-            MaterializedResult r = this.computeActual(session, String.format("SHOW STATS FOR \"test@%d\"", snapshot));
+            MaterializedResult r = this.computeActual(session, String.format("SHOW STATS FOR \"test_stats_sample_prev@%d\"", snapshot));
             int max = Integer.parseInt(r.getMaterializedRows().get(0).getField(6).toString());
             int min = Integer.parseInt(r.getMaterializedRows().get(0).getField(5).toString());
             assertEquals(min, 2);
@@ -153,22 +153,22 @@ public class TestIcebergTableSampling
         Session session = Session.builder(getSession())
                 .setSystemProperty("iceberg." + IcebergSessionProperties.USE_SAMPLE_STATISTICS, "true")
                 .build();
-        assertQuerySucceeds("DROP TABLE IF EXISTS test");
-        assertQuerySucceeds("CREATE TABLE test(i int)");
-        assertUpdate("INSERT INTO test VALUES(1)", 1);
-        assertQuerySucceeds("CALL iceberg.system.create_sample_table('tpch', 'test', 'i')");
-        assertUpdate("INSERT INTO \"test$samples\" VALUES (2)", 1);
-        assertUpdate("INSERT INTO test (VALUES (1), (2), (3), (4), (5), (6), (7))", 7);
-        assertUpdate("INSERT INTO test VALUES(2)", 1);
-        assertUpdate("INSERT INTO test VALUES(3)", 1);
-        assertUpdate("INSERT INTO test VALUES(5)", 1);
-        assertUpdate("INSERT INTO test VALUES(6)", 1);
-        assertUpdate("INSERT INTO \"test$samples\" ( VALUES (3), (1) )", 2);
-        List<Long> actualSnapshots = getSnapshotIds(session, "test");
+        assertQuerySucceeds("DROP TABLE IF EXISTS test_stats_sample_next");
+        assertQuerySucceeds("CREATE TABLE test_stats_sample_next(i int)");
+        assertUpdate("INSERT INTO test_stats_sample_next VALUES(1)", 1);
+        assertQuerySucceeds("CALL iceberg.system.create_sample_table('tpch', 'test_stats_sample_next', 'i')");
+        assertUpdate("INSERT INTO \"test_stats_sample_next$samples\" VALUES (2)", 1);
+        assertUpdate("INSERT INTO test_stats_sample_next (VALUES (1), (2), (3), (4), (5), (6), (7))", 7);
+        assertUpdate("INSERT INTO test_stats_sample_next VALUES(2)", 1);
+        assertUpdate("INSERT INTO test_stats_sample_next VALUES(3)", 1);
+        assertUpdate("INSERT INTO test_stats_sample_next VALUES(5)", 1);
+        assertUpdate("INSERT INTO test_stats_sample_next VALUES(6)", 1);
+        assertUpdate("INSERT INTO \"test_stats_sample_next$samples\" ( VALUES (3), (1) )", 2);
+        List<Long> actualSnapshots = getSnapshotIds(session, "test_stats_sample_next");
         List<Long> snapshotsUsingNext = actualSnapshots.subList(1, actualSnapshots.size());
 
         for (Long snapshot : snapshotsUsingNext) {
-            MaterializedResult r = this.computeActual(session, String.format("SHOW STATS FOR \"test@%d\"", snapshot));
+            MaterializedResult r = this.computeActual(session, String.format("SHOW STATS FOR \"test_stats_sample_next@%d\"", snapshot));
             int max = Integer.parseInt(r.getMaterializedRows().get(0).getField(6).toString());
             int min = Integer.parseInt(r.getMaterializedRows().get(0).getField(5).toString());
             assertEquals(min, 1);
@@ -182,13 +182,13 @@ public class TestIcebergTableSampling
         Session session = Session.builder(getSession())
                 .setSystemProperty("iceberg." + IcebergSessionProperties.USE_SAMPLE_STATISTICS, "true")
                 .build();
-        assertQuerySucceeds("DROP TABLE IF EXISTS test");
-        assertQuerySucceeds("CREATE TABLE test(i int)");
-        assertUpdate("INSERT INTO test VALUES(1)", 1);
-        assertQuerySucceeds("CALL iceberg.system.create_sample_table('tpch', 'test', 'i')");
-        assertUpdate("INSERT INTO \"test$samples\" VALUES (2)", 1);
-        assertUpdate("INSERT INTO test (VALUES (1), (2), (3), (4), (5), (6), (7))", 7);
-        MaterializedResult r = this.computeActual(session, "SHOW STATS FOR test");
+
+        assertQuerySucceeds("CREATE TABLE test_stats_no_sample_actual(i int)");
+        assertUpdate("INSERT INTO test_stats_no_sample_actual VALUES(1)", 1);
+        assertQuerySucceeds("CALL iceberg.system.create_sample_table('tpch', 'test_stats_no_sample_actual', 'i')");
+        assertUpdate("INSERT INTO \"test_stats_no_sample_actual$samples\" VALUES (2)", 1);
+        assertUpdate("INSERT INTO test_stats_no_sample_actual (VALUES (1), (2), (3), (4), (5), (6), (7))", 7);
+        MaterializedResult r = this.computeActual(session, "SHOW STATS FOR test_stats_no_sample_actual");
         int max = Integer.parseInt(r.getMaterializedRows().get(0).getField(6).toString());
         int min = Integer.parseInt(r.getMaterializedRows().get(0).getField(5).toString());
         assertEquals(min, 2);

--- a/presto-iceberg/src/test/java/com/facebook/presto/iceberg/TestIcebergTableSampling.java
+++ b/presto-iceberg/src/test/java/com/facebook/presto/iceberg/TestIcebergTableSampling.java
@@ -52,21 +52,21 @@ public class TestIcebergTableSampling
     @Test
     public void testCreateSampleTable()
     {
-        assertUpdate("CALL iceberg.system.create_sample_table('tpch', 'lineitem')");
+        assertUpdate("CALL iceberg.system.create_sample_table('tpch', 'lineitem', 'orderkey')");
         assertQuerySucceeds("SELECT count(*) FROM \"lineitem$samples\"");
     }
 
     @Test
     public void testInsertIntoSampleTable()
     {
-        assertQuerySucceeds("CALL iceberg.system.create_sample_table('tpch', 'lineitem')");
+        assertQuerySucceeds("CALL iceberg.system.create_sample_table('tpch', 'lineitem', 'orderkey')");
         assertUpdate("INSERT INTO \"lineitem$samples\" SELECT * FROM tpch.lineitem LIMIT 3", 3);
     }
 
     @Test
     public void testQuerySampleTable()
     {
-        assertQuerySucceeds("CALL iceberg.system.create_sample_table('tpch', 'lineitem')");
+        assertQuerySucceeds("CALL iceberg.system.create_sample_table('tpch', 'lineitem', 'orderkey')");
         assertUpdate("INSERT INTO \"lineitem$samples\" SELECT * FROM tpch.lineitem LIMIT 3", 3);
         assertQuerySucceeds("SELECT * FROM \"lineitem$samples\"");
         assertQuerySucceeds("SELECT count(*) FROM \"lineitem$samples\"");
@@ -75,7 +75,7 @@ public class TestIcebergTableSampling
     @Test
     public void testGetStatsForSampleExplicit()
     {
-        assertQuerySucceeds("CALL iceberg.system.create_sample_table('tpch', 'lineitem')");
+        assertQuerySucceeds("CALL iceberg.system.create_sample_table('tpch', 'lineitem', 'orderkey')");
         assertUpdate("INSERT INTO \"lineitem$samples\" SELECT * FROM tpch.lineitem LIMIT 3", 3);
         assertQuerySucceeds("SHOW STATS FOR \"lineitem$samples\"");
     }
@@ -90,7 +90,7 @@ public class TestIcebergTableSampling
         assertQuerySucceeds("DROP TABLE IF EXISTS test");
         assertQuerySucceeds("CREATE TABLE test(i int)");
         assertUpdate("INSERT INTO test VALUES(1)", 1);
-        assertQuerySucceeds("CALL iceberg.system.create_sample_table('tpch', 'test')");
+        assertQuerySucceeds("CALL iceberg.system.create_sample_table('tpch', 'test', 'i')");
         assertUpdate("INSERT INTO \"test$samples\" VALUES (2)", 1);
         MaterializedResult r = this.computeActual(session, "SHOW STATS FOR test");
         int max = Integer.parseInt(r.getMaterializedRows().get(0).getField(6).toString());
@@ -109,7 +109,7 @@ public class TestIcebergTableSampling
         assertQuerySucceeds("DROP TABLE IF EXISTS test");
         assertQuerySucceeds("CREATE TABLE test(i int)");
         assertUpdate("INSERT INTO test VALUES(1)", 1);
-        assertQuerySucceeds("CALL iceberg.system.create_sample_table('tpch', 'test')");
+        assertQuerySucceeds("CALL iceberg.system.create_sample_table('tpch', 'test', 'i')");
         assertUpdate("INSERT INTO \"test$samples\" VALUES (2)", 1);
         MaterializedResult r = this.computeActual(session, "SHOW STATS FOR test");
         int max = Integer.parseInt(r.getMaterializedRows().get(0).getField(6).toString());
@@ -128,7 +128,7 @@ public class TestIcebergTableSampling
         assertQuerySucceeds("DROP TABLE IF EXISTS test");
         assertQuerySucceeds("CREATE TABLE test(i int)");
         assertUpdate("INSERT INTO test VALUES(1)", 1);
-        assertQuerySucceeds("CALL iceberg.system.create_sample_table('tpch', 'test')");
+        assertQuerySucceeds("CALL iceberg.system.create_sample_table('tpch', 'test', 'i')");
         assertUpdate("INSERT INTO \"test$samples\" VALUES (2)", 1);
         assertUpdate("INSERT INTO test VALUES(2)", 1);
         assertUpdate("INSERT INTO test VALUES(3)", 1);
@@ -156,7 +156,7 @@ public class TestIcebergTableSampling
         assertQuerySucceeds("DROP TABLE IF EXISTS test");
         assertQuerySucceeds("CREATE TABLE test(i int)");
         assertUpdate("INSERT INTO test VALUES(1)", 1);
-        assertQuerySucceeds("CALL iceberg.system.create_sample_table('tpch', 'test')");
+        assertQuerySucceeds("CALL iceberg.system.create_sample_table('tpch', 'test', 'i')");
         assertUpdate("INSERT INTO \"test$samples\" VALUES (2)", 1);
         assertUpdate("INSERT INTO test (VALUES (1), (2), (3), (4), (5), (6), (7))", 7);
         assertUpdate("INSERT INTO test VALUES(2)", 1);
@@ -185,7 +185,7 @@ public class TestIcebergTableSampling
         assertQuerySucceeds("DROP TABLE IF EXISTS test");
         assertQuerySucceeds("CREATE TABLE test(i int)");
         assertUpdate("INSERT INTO test VALUES(1)", 1);
-        assertQuerySucceeds("CALL iceberg.system.create_sample_table('tpch', 'test')");
+        assertQuerySucceeds("CALL iceberg.system.create_sample_table('tpch', 'test', 'i')");
         assertUpdate("INSERT INTO \"test$samples\" VALUES (2)", 1);
         assertUpdate("INSERT INTO test (VALUES (1), (2), (3), (4), (5), (6), (7))", 7);
         MaterializedResult r = this.computeActual(session, "SHOW STATS FOR test");


### PR DESCRIPTION
This commit exposes a new system table called $changelog that allows users to return a table pertaining to info about when which snapshots specific records were added or deleted.

The schema of the changelog table is as follows:
```
| primary_key: T | operation: VARCHAR | ordinal: bigint | snapshot_id: bigint |
```

To use this feature, the only requirement is that users need to specify the name of a column in the table properties as the "primary key". The value of the key will be exposes in the "primary_key" column of the changelog table. The type of the column will be the same type as in the underlying table.

The current beahvior in this commit only returns the results of the changelog between the current and previous snapshot of the table being queried. You can use this information to determine when a record has been inserted or deleted.

```sql
SELECT committed_at, change.operation, primary_key, ordinal
    FROM "orders$snapshots" as snap
    JOIN "orders$changelog" as change
    ON change.snapshot_id = snap.snapshot_id;
```
```

                committed_at                 | operation | primary_key | ordinal
---------------------------------------------+-----------+-------------+---------
 2023-07-19 13:03:03.207 America/Los_Angeles | INSERT    |        1956 |       0
 2023-07-19 13:03:03.207 America/Los_Angeles | INSERT    |       28196 |       0
 2023-07-19 13:03:03.207 America/Los_Angeles | INSERT    |       27873 |       0
```

At a high-level the implementation strategy needed to expose information from Iceberg's IncrementalChangelogScan tasks which differs from a normal TableScan. The plan tasks for IncrementalScans include the information on operation type, ordinal, and snapshotId which are are not contained in the normal table scan plan.

When the connector metadata queries for a changelog table type, it returns a schema with a static 4 columns, where the first 3 are static VARCHAR, BIGINT, BIGINT, and the final is dependent upon the user- defined primary key property.

To accomplish this the following changes were made
- a new primary key table property was added
- logic to generate the changelog table schema
- a new piece of info on iceberg splits containing the original table's column handles which is used during split sourcing
- a new page source which constructs the correct format page based on the extracted primary key.
- finally, some additional refactoring of the IcebergNativeMetadata and IcebergHiveMetadata classes to consolidate certain bits of logic for the ConnectorMetadata

And of course, this is preliminary work. There is still some more optimization that could be done.
