### PR TITLE
Add a function to aggregate the changelog

### DIFF
--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergPlugin.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergPlugin.java
@@ -13,7 +13,7 @@
  */
 package com.facebook.presto.iceberg;
 
-import com.facebook.presto.iceberg.function.changelog.ChangelogCoalesceFunction;
+import com.facebook.presto.iceberg.function.changelog.ApplyChangelogFunction;
 import com.facebook.presto.spi.Plugin;
 import com.facebook.presto.spi.connector.ConnectorFactory;
 import com.google.common.collect.ImmutableList;
@@ -34,7 +34,7 @@ public class IcebergPlugin
     public Set<Class<?>> getFunctions()
     {
         return ImmutableSet.<Class<?>>builder()
-                .add(ChangelogCoalesceFunction.class)
+                .add(ApplyChangelogFunction.class)
                 .build();
     }
 }

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/function/changelog/ApplyChangelogState.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/function/changelog/ApplyChangelogState.java
@@ -20,7 +20,7 @@ import com.facebook.presto.spi.function.AccumulatorState;
 
 import static java.util.Objects.requireNonNull;
 
-public interface ChangelogCoalesceState
+public interface ApplyChangelogState
         extends AccumulatorState
 {
     public Type getType();
@@ -30,7 +30,7 @@ public interface ChangelogCoalesceState
     void set(ChangelogRecord value);
 
     class Single
-            implements ChangelogCoalesceState
+            implements ApplyChangelogState
     {
         private final Type innerType;
         ChangelogRecord record;
@@ -70,7 +70,7 @@ public interface ChangelogCoalesceState
 
     class Grouped
             extends AbstractGroupedAccumulatorState
-            implements ChangelogCoalesceState
+            implements ApplyChangelogState
     {
         private final ObjectBigArray<ChangelogRecord> records = new ObjectBigArray<>();
         private long size;

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/function/changelog/ApplyChangelogStateFactory.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/function/changelog/ApplyChangelogStateFactory.java
@@ -18,37 +18,37 @@ import com.facebook.presto.spi.function.AccumulatorStateFactory;
 
 import static java.util.Objects.requireNonNull;
 
-public class ChangelogCoalesceStateFactory
-        implements AccumulatorStateFactory<ChangelogCoalesceState>
+public class ApplyChangelogStateFactory
+        implements AccumulatorStateFactory<ApplyChangelogState>
 {
     private final Type type;
 
-    public ChangelogCoalesceStateFactory(Type type)
+    public ApplyChangelogStateFactory(Type type)
     {
         this.type = requireNonNull(type, "type is null");
     }
 
     @Override
-    public ChangelogCoalesceState createSingleState()
+    public ApplyChangelogState createSingleState()
     {
-        return new ChangelogCoalesceState.Single(type);
+        return new ApplyChangelogState.Single(type);
     }
 
     @Override
-    public Class<? extends ChangelogCoalesceState> getSingleStateClass()
+    public Class<? extends ApplyChangelogState> getSingleStateClass()
     {
-        return ChangelogCoalesceState.Single.class;
+        return ApplyChangelogState.Single.class;
     }
 
     @Override
-    public ChangelogCoalesceState.Grouped createGroupedState()
+    public ApplyChangelogState.Grouped createGroupedState()
     {
-        return new ChangelogCoalesceState.Grouped(type);
+        return new ApplyChangelogState.Grouped(type);
     }
 
     @Override
-    public Class<? extends ChangelogCoalesceState> getGroupedStateClass()
+    public Class<? extends ApplyChangelogState> getGroupedStateClass()
     {
-        return ChangelogCoalesceState.Grouped.class;
+        return ApplyChangelogState.Grouped.class;
     }
 }

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/function/changelog/ApplyChangelogStateSerializer.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/function/changelog/ApplyChangelogStateSerializer.java
@@ -22,18 +22,13 @@ import com.facebook.presto.common.type.VarcharType;
 import com.facebook.presto.spi.function.AccumulatorStateSerializer;
 import com.google.common.collect.ImmutableList;
 
-import static java.util.Objects.requireNonNull;
-
-final class ChangelogCoalesceStateSerializer
-        implements AccumulatorStateSerializer<ChangelogCoalesceState>
+final class ApplyChangelogStateSerializer
+        implements AccumulatorStateSerializer<ApplyChangelogState>
 {
-    private final Type innerType;
-
     private final Type serializedType;
 
-    public ChangelogCoalesceStateSerializer(Type innerType)
+    public ApplyChangelogStateSerializer(Type innerType)
     {
-        this.innerType = requireNonNull(innerType, "innerType is null");
         this.serializedType = getSerializedRowType(innerType);
     }
 
@@ -49,7 +44,7 @@ final class ChangelogCoalesceStateSerializer
     }
 
     @Override
-    public void serialize(ChangelogCoalesceState state, BlockBuilder out)
+    public void serialize(ApplyChangelogState state, BlockBuilder out)
     {
         if (state.get() == null) {
             out.appendNull();
@@ -60,7 +55,7 @@ final class ChangelogCoalesceStateSerializer
     }
 
     @Override
-    public void deserialize(Block block, int index, ChangelogCoalesceState state)
+    public void deserialize(Block block, int index, ApplyChangelogState state)
     {
         ChangelogRecord record = new ChangelogRecord(state.getType());
         record.deserialize(block, index);


### PR DESCRIPTION
This change introduces an aggregation function which
combines inputs in order to determine the  final set of
values for the changes in an iceberg table's changelog.

The current method is to implement the coalescing as an
aggregation function which is to be called in a query grouped
by the primary key. If duplicates are found, the function will
fail.

A sample usage of this function would be like:

```sql
SELECT primary_key, apply_changelog(ordinal, operation, rowdata order by ordinal)
FROM "table$changelog"
GROUP BY primary_key
```

The resulting output will look something like:

```sql
| primary_key | rowdata |
|-------------+---------|
| 12359       | { ... } |
| 5555        | NULL    |
| 121         | { ... } |
|          ....         |
|-------------+---------|
```

where a `NULL` value indicates that a particular key was
deleted from the table. Non-null indicates a row update or
insert.

For the purposes of updating the sample, the only way to
tell the difference between an insert or an update is if the
key existed in the snapshot of the table for the version the
changelog starts from. This would potentially require an extra query