### PR TITLE
Add arguments for merging into an initial sample

### DIFF
--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/function/changelog/ApplyChangelogState.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/function/changelog/ApplyChangelogState.java
@@ -23,7 +23,7 @@ import static java.util.Objects.requireNonNull;
 public interface ApplyChangelogState
         extends AccumulatorState
 {
-    public Type getType();
+    Type getType();
 
     ChangelogRecord get();
 

--- a/presto-main/src/main/java/com/facebook/presto/operator/aggregation/reservoirsample/CreateSampleFunction.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/aggregation/reservoirsample/CreateSampleFunction.java
@@ -18,7 +18,6 @@ import com.facebook.presto.common.block.Block;
 import com.facebook.presto.common.block.BlockBuilder;
 import com.facebook.presto.common.type.ArrayType;
 import com.facebook.presto.common.type.RowType;
-import com.facebook.presto.common.type.StandardTypes;
 import com.facebook.presto.common.type.Type;
 import com.facebook.presto.metadata.BoundVariables;
 import com.facebook.presto.metadata.FunctionAndTypeManager;
@@ -34,12 +33,14 @@ import com.facebook.presto.spi.function.aggregation.GroupedAccumulator;
 import com.google.common.collect.ImmutableList;
 
 import java.lang.invoke.MethodHandle;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 
 import static com.facebook.presto.common.type.BigintType.BIGINT;
-import static com.facebook.presto.common.type.IntegerType.INTEGER;
 import static com.facebook.presto.common.type.TypeSignature.parseTypeSignature;
 import static com.facebook.presto.operator.aggregation.AggregationUtils.generateAggregationName;
 import static com.facebook.presto.spi.function.Signature.typeVariable;
@@ -48,6 +49,7 @@ import static com.facebook.presto.spi.function.aggregation.AggregationMetadata.P
 import static com.facebook.presto.spi.function.aggregation.AggregationMetadata.ParameterMetadata.ParameterType.NULLABLE_BLOCK_INPUT_CHANNEL;
 import static com.facebook.presto.spi.function.aggregation.AggregationMetadata.ParameterMetadata.ParameterType.STATE;
 import static com.facebook.presto.util.Reflection.methodHandle;
+import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.collect.ImmutableList.toImmutableList;
 
 public class CreateSampleFunction
@@ -55,7 +57,7 @@ public class CreateSampleFunction
 {
     public static final CreateSampleFunction RESERVOIR_SAMPLE = new CreateSampleFunction();
     private static final String NAME = "reservoir_sample";
-    private static final MethodHandle INPUT_FUNCTION = methodHandle(CreateSampleFunction.class, "input", Type.class, ReservoirSampleState.class, Block.class, int.class, long.class);
+    private static final MethodHandle INPUT_FUNCTION = methodHandle(CreateSampleFunction.class, "input", Type.class, ReservoirSampleState.class, Block.class, int.class, long.class, Block.class, int.class, long.class);
     private static final MethodHandle COMBINE_FUNCTION = methodHandle(CreateSampleFunction.class, "combine", Type.class, ReservoirSampleState.class, ReservoirSampleState.class);
     private static final MethodHandle OUTPUT_FUNCTION = methodHandle(CreateSampleFunction.class, "output", Type.class, ReservoirSampleState.class, BlockBuilder.class);
 
@@ -63,8 +65,9 @@ public class CreateSampleFunction
     {
         super(NAME, ImmutableList.of(typeVariable("T")),
                 ImmutableList.of(),
-                parseTypeSignature("row(integer,array(T))"),
-                ImmutableList.of(parseTypeSignature("T"), parseTypeSignature(StandardTypes.BIGINT)));
+                parseTypeSignature("row(count integer, sample array(T))"),
+                // initial sample array (scalar value), initial seen count (scalar value), new set of samples to insert, reservoir size (scalar)
+                ImmutableList.of(parseTypeSignature("array(T)"), BIGINT.getTypeSignature(), parseTypeSignature("T"), BIGINT.getTypeSignature()));
     }
 
     private static BuiltInAggregationFunctionImplementation generateAggregation(Type type)
@@ -72,7 +75,7 @@ public class CreateSampleFunction
         DynamicClassLoader classLoader = new DynamicClassLoader(CreateSampleFunction.class.getClassLoader());
         AccumulatorStateSerializer<?> stateSerializer = new ReservoirSampleStateSerializer(type);
         AccumulatorStateFactory<?> stateFactory = new ReservoirSampleStateFactory(type);
-        List<Type> inputTypes = ImmutableList.of(type, BIGINT);
+        List<Type> inputTypes = ImmutableList.of(new ArrayType(type), BIGINT, type, BIGINT);
         Type outputType = createOutputType(type);
         Type intermediateType = stateSerializer.getSerializedType();
         List<AggregationMetadata.ParameterMetadata> inputParameterMetadata = createInputParameterMetadata(type);
@@ -109,7 +112,7 @@ public class CreateSampleFunction
 
     private static Type createOutputType(Type type)
     {
-        RowType.Field count = new RowType.Field(Optional.of("count"), INTEGER);
+        RowType.Field count = new RowType.Field(Optional.of("count"), BIGINT);
         RowType.Field sample = new RowType.Field(Optional.of("sample"), new ArrayType(type));
         List<RowType.Field> fields = Arrays.asList(count, sample);
         return RowType.from(fields);
@@ -121,12 +124,17 @@ public class CreateSampleFunction
                 new AggregationMetadata.ParameterMetadata(STATE),
                 new AggregationMetadata.ParameterMetadata(NULLABLE_BLOCK_INPUT_CHANNEL, type),
                 new AggregationMetadata.ParameterMetadata(BLOCK_INDEX),
+                new AggregationMetadata.ParameterMetadata(INPUT_CHANNEL, BIGINT),
+                new AggregationMetadata.ParameterMetadata(NULLABLE_BLOCK_INPUT_CHANNEL, type),
+                new AggregationMetadata.ParameterMetadata(BLOCK_INDEX),
                 new AggregationMetadata.ParameterMetadata(INPUT_CHANNEL, BIGINT));
     }
 
-    public static void input(Type type, ReservoirSampleState state, Block value, int position, long n)
+    public static void input(Type type, ReservoirSampleState state, Block initialState, int pos, long seenCount, Block value, int position, long n)
     {
         state.add(value, position, n);
+        state.initializeInitialSample(initialState);
+        state.initializeInitialSeenCount(seenCount);
     }
 
     public static void combine(Type type, ReservoirSampleState state, ReservoirSampleState otherState)
@@ -137,11 +145,22 @@ public class CreateSampleFunction
     public static void output(Type elementType, ReservoirSampleState state, BlockBuilder out)
     {
         ReservoirSample reservoirSample = state.getSamples();
+        Block initialSampleBlock = state.getInitialSample();
+        long initialSeenCount = state.getInitialSeenCount();
+        // merge the final state with the initial state given
+        List<Block> samples = IntStream.range(0, initialSampleBlock.getPositionCount())
+                .mapToObj(initialSampleBlock::getSingleValueBlock)
+                .collect(Collectors.toList());
+        if (initialSeenCount != initialSampleBlock.getPositionCount()) {
+            checkArgument(reservoirSample.getMaxSampleSize() == initialSampleBlock.getPositionCount(), "initial sample size must be equal to the sample size");
+        }
+        ReservoirSample finalSample = new ReservoirSample(elementType, initialSeenCount, reservoirSample.getMaxSampleSize(), new ArrayList<>(samples));
+        finalSample.merge(reservoirSample);
         Type arrayType = new ArrayType(elementType);
-        int count = reservoirSample.getSeenCount();
+        long count = finalSample.getSeenCount();
         BlockBuilder entryBuilder = out.beginBlockEntry();
-        INTEGER.writeLong(entryBuilder, count);
-        BlockBuilder sampleBlock = reservoirSample.getSampleBlockBuilder();
+        BIGINT.writeLong(entryBuilder, count);
+        BlockBuilder sampleBlock = finalSample.getSampleBlockBuilder();
         arrayType.appendTo(sampleBlock.build(), 0, entryBuilder);
         out.closeEntry();
     }

--- a/presto-main/src/main/java/com/facebook/presto/operator/aggregation/reservoirsample/GroupReservoirSampleState.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/aggregation/reservoirsample/GroupReservoirSampleState.java
@@ -14,10 +14,14 @@
 package com.facebook.presto.operator.aggregation.reservoirsample;
 
 import com.facebook.presto.common.type.Type;
+import com.facebook.presto.spi.function.GroupedAccumulatorState;
 
 public class GroupReservoirSampleState
         extends ReservoirSampleState
+        implements GroupedAccumulatorState
 {
+    private long groupId;
+
     public GroupReservoirSampleState(Type type)
     {
         super(type);
@@ -26,5 +30,16 @@ public class GroupReservoirSampleState
     public GroupReservoirSampleState(ReservoirSampleState other)
     {
         super(other);
+    }
+
+    @Override
+    public void setGroupId(long groupId)
+    {
+        this.groupId = groupId;
+    }
+
+    @Override
+    public void ensureCapacity(long size)
+    {
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/operator/aggregation/reservoirsample/ReservoirSample.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/aggregation/reservoirsample/ReservoirSample.java
@@ -20,9 +20,10 @@ import com.facebook.presto.common.type.Type;
 import io.airlift.slice.SizeOf;
 import org.openjdk.jol.info.ClassLayout;
 
-import java.util.Arrays;
+import java.util.ArrayList;
 import java.util.concurrent.ThreadLocalRandom;
 
+import static com.facebook.presto.common.type.BigintType.BIGINT;
 import static com.facebook.presto.common.type.IntegerType.INTEGER;
 import static com.google.common.base.Preconditions.checkArgument;
 import static java.lang.String.format;
@@ -33,89 +34,111 @@ public class ReservoirSample
 {
     private static final int INSTANCE_SIZE = ClassLayout.parseClass(ReservoirSampleState.class).instanceSize();
     private final Type type;
-    //    private BlockBuilder blockBuilder;
-    private Block[] samples;
-    private int seenCount;
-    private boolean isEmpty = true;
-    private boolean sampleInitialized;
+    private final Type arrayType;
+    private ArrayList<Block> samples;
+    private int maxSampleSize = -1;
+    private long seenCount;
 
     public ReservoirSample(Type type)
     {
         this.type = requireNonNull(type, "type is null");
+        this.arrayType = new ArrayType(type);
+        this.samples = new ArrayList<>();
     }
 
     public ReservoirSample(ReservoirSample other)
     {
         this.type = other.type;
+        this.arrayType = new ArrayType(type);
         this.seenCount = other.seenCount;
-        this.samples = Arrays.copyOf(requireNonNull(other.samples, "samples is null"), other.samples.length);
-        this.sampleInitialized = true;
+        this.samples = (ArrayList<Block>) other.samples.clone();
+        this.maxSampleSize = other.maxSampleSize;
     }
 
-    public ReservoirSample(int seenCount, Block[] samples, Type type)
+    public ReservoirSample(Type type, long seenCount, int maxSampleSize, ArrayList<Block> samples)
     {
         this.type = type;
+        this.arrayType = new ArrayType(type);
         this.seenCount = seenCount;
         this.samples = samples;
-        this.sampleInitialized = true;
+        this.maxSampleSize = maxSampleSize;
     }
 
-    private static Block[] mergeBlockSamples(Block[] samples1, Block[] samples2, int seenCount1, int seenCount2)
+    private static ArrayList<Block> mergeBlockSamples(ArrayList<Block> samples1, ArrayList<Block> samples2, long seenCount1, long seenCount2)
     {
         int nextIndex = 0;
         int otherNextIndex = 0;
-        Block[] merged = new Block[samples1.length];
-        for (int i = 0; i < samples1.length; i++) {
+        ArrayList<Block> merged = new ArrayList<>(samples1.size());
+        for (int i = 0; i < samples1.size(); i++) {
             if (ThreadLocalRandom.current().nextLong(0, seenCount1 + seenCount2) < seenCount1) {
-                merged[i] = samples1[nextIndex++];
+                merged.add(samples1.get(nextIndex++));
             }
             else {
-                merged[i] = samples2[otherNextIndex++];
+                merged.add(samples2.get(otherNextIndex++));
             }
         }
         return merged;
     }
 
-    private static void shuffleBlockArray(Block[] samples)
+    private static void shuffleBlockArray(ArrayList<Block> samples)
     {
-        for (int i = samples.length - 1; i > 0; i--) {
+        for (int i = samples.size() - 1; i > 0; i--) {
             int index = ThreadLocalRandom.current().nextInt(0, i + 1);
-            Block sample = samples[index];
-            samples[index] = samples[i];
-            samples[i] = sample;
+            Block sample = samples.get(index);
+            samples.set(index, samples.get(i));
+            samples.set(i, sample);
         }
     }
 
-    public void initializeSample(long n)
+    public void initializeSample(int n)
     {
-        samples = new Block[(int) n];
-        sampleInitialized = true;
+        samples = new ArrayList<>(n);
+        maxSampleSize = n;
+    }
+
+    private boolean sampleNotInitialized()
+    {
+        return maxSampleSize < 0;
     }
 
     public int getSampleSize()
     {
-        if (isSampleInitialized()) {
-            return samples.length;
+        if (sampleNotInitialized()) {
+            return 0;
         }
-        return 0;
+        return samples.size();
     }
 
-    public void add(Block block, int position)
+    public int getMaxSampleSize()
     {
-        isEmpty = false;
+        return maxSampleSize;
+    }
+
+    /**
+     * Potentially add a value from a block at a given position into the sample.
+     *
+     * @param block the block containing the potential sample
+     * @param position the position in the block to potentially insert
+     * @param n the maximum size of the sample in case it is not initialized
+     */
+    public void add(Block block, int position, long n)
+    {
+        if (sampleNotInitialized()) {
+            initializeSample((int) n);
+        }
         seenCount++;
-        int sampleSize = getSampleSize();
+        int sampleSize = getMaxSampleSize();
         if (seenCount <= sampleSize) {
-            BlockBuilder sampleBlock = type.createBlockBuilder(null, 16);
+            BlockBuilder sampleBlock = type.createBlockBuilder(null, 1);
             type.appendTo(block, position, sampleBlock);
-            samples[seenCount - 1] = sampleBlock.build();
+            samples.add(sampleBlock.build());
         }
         else {
-            int index = ThreadLocalRandom.current().nextInt(0, seenCount);
-            if (index < samples.length) {
-                BlockBuilder sampleBlock = type.createBlockBuilder(null, 16);
+            long index = ThreadLocalRandom.current().nextLong(0, seenCount);
+            if (index < samples.size()) {
+                BlockBuilder sampleBlock = type.createBlockBuilder(null, 1);
                 type.appendTo(block, position, sampleBlock);
-                samples[index] = sampleBlock.build();
+                samples.set((int) index, sampleBlock.build());
             }
         }
     }
@@ -123,35 +146,35 @@ public class ReservoirSample
     private void addSingleBlock(Block block)
     {
         seenCount++;
-        int sampleSize = getSampleSize();
+        int sampleSize = getMaxSampleSize();
         if (seenCount <= sampleSize) {
-            samples[seenCount - 1] = block;
+            samples.add(block);
         }
         else {
-            int index = ThreadLocalRandom.current().nextInt(0, seenCount);
-            if (index < samples.length) {
-                samples[index] = block;
+            long index = ThreadLocalRandom.current().nextLong(0L, seenCount);
+            if (index < samples.size()) {
+                samples.set((int) index, block);
             }
         }
     }
 
     public void merge(ReservoirSample other)
     {
-        if (!sampleInitialized) {
-            initializeSample(other.samples.length);
+        if (sampleNotInitialized()) {
+            initializeSample(other.getMaxSampleSize());
         }
         checkArgument(
-                samples.length == other.samples.length,
-                format("Maximum number of samples %s must be equal to that of other %s", samples.length, other.samples.length));
-        if (other.seenCount < other.samples.length) {
-            for (int i = 0; i < other.seenCount; i++) {
-                addSingleBlock(other.samples[i]);
+                getMaxSampleSize() == other.getMaxSampleSize(),
+                format("maximum number of samples %s must be equal to that of other %s", getMaxSampleSize(), other.getMaxSampleSize()));
+        if (other.seenCount < getMaxSampleSize()) {
+            for (int i = 0; i < other.samples.size(); i++) {
+                addSingleBlock(other.samples.get(i));
             }
             return;
         }
-        if (seenCount < samples.length) {
+        if (seenCount < getMaxSampleSize()) {
             for (int i = 0; i < seenCount; i++) {
-                other.addSingleBlock(samples[i]);
+                other.addSingleBlock(samples.get(i));
             }
             seenCount = other.seenCount;
             samples = other.samples;
@@ -173,46 +196,39 @@ public class ReservoirSample
         return type;
     }
 
-    public Block[] getSampleArray()
+    public ArrayList<Block> getSampleArray()
     {
         return samples;
     }
 
-    public boolean isEmpty()
-    {
-        return isEmpty;
-    }
-
-    public int getSeenCount()
+    public long getSeenCount()
     {
         return seenCount;
-    }
-
-    public boolean isSampleInitialized()
-    {
-        return sampleInitialized;
     }
 
     public long estimatedInMemorySize()
     {
         return INSTANCE_SIZE +
-                SizeOf.sizeOf(samples);
+                SizeOf.sizeOfObjectArray(samples.size());
     }
 
     public void serialize(BlockBuilder out)
     {
         BlockBuilder sampleBlock = getSampleBlockBuilder();
-        INTEGER.writeLong(out, seenCount);
-        INTEGER.writeLong(out, samples.length);
-        new ArrayType(type).appendTo(sampleBlock.build(), 0, out);
+
+        BIGINT.writeLong(out, seenCount);
+        INTEGER.writeLong(out, maxSampleSize);
+        INTEGER.writeLong(out, samples.size());
+        arrayType.appendTo(sampleBlock.build(), 0, out);
     }
 
     BlockBuilder getSampleBlockBuilder()
     {
-        BlockBuilder sampleBlock = new ArrayType(type).createBlockBuilder(null, 16);
+        int sampleSize = getSampleSize();
+        BlockBuilder sampleBlock = arrayType.createBlockBuilder(null, sampleSize);
         BlockBuilder sampleEntryBuilder = sampleBlock.beginBlockEntry();
-        for (Block sample : samples) {
-            type.appendTo(sample, 0, sampleEntryBuilder);
+        for (int i = 0; i < sampleSize; i++) {
+            type.appendTo(samples.get(i), 0, sampleEntryBuilder);
         }
         sampleBlock.closeEntry();
         return sampleBlock;

--- a/presto-main/src/main/java/com/facebook/presto/operator/aggregation/reservoirsample/ReservoirSample.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/aggregation/reservoirsample/ReservoirSample.java
@@ -26,6 +26,7 @@ import java.util.concurrent.ThreadLocalRandom;
 import static com.facebook.presto.common.type.BigintType.BIGINT;
 import static com.facebook.presto.common.type.IntegerType.INTEGER;
 import static com.google.common.base.Preconditions.checkArgument;
+import static java.lang.Math.max;
 import static java.lang.String.format;
 import static java.util.Objects.requireNonNull;
 
@@ -92,7 +93,7 @@ public class ReservoirSample
 
     public void initializeSample(int n)
     {
-        samples = new ArrayList<>(n);
+        samples = new ArrayList<>(max(n, 0));
         maxSampleSize = n;
     }
 

--- a/presto-main/src/main/java/com/facebook/presto/operator/aggregation/reservoirsample/ReservoirSampleState.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/aggregation/reservoirsample/ReservoirSampleState.java
@@ -15,37 +15,52 @@ package com.facebook.presto.operator.aggregation.reservoirsample;
 
 import com.facebook.presto.common.block.Block;
 import com.facebook.presto.common.block.BlockBuilder;
+import com.facebook.presto.common.type.ArrayType;
 import com.facebook.presto.common.type.Type;
 import com.facebook.presto.spi.function.AccumulatorState;
+
+import static com.facebook.presto.common.type.BigintType.BIGINT;
 
 public class ReservoirSampleState
         implements AccumulatorState
 {
     private ReservoirSample sample;
-    private boolean isEmpty = true;
+    private final Type arrayType;
+
+    private Block initialSample;
+    private long initialSeenCount = -1;
 
     public ReservoirSampleState(Type type)
     {
         sample = new ReservoirSample(type);
+        arrayType = new ArrayType(type);
     }
 
     public ReservoirSampleState(ReservoirSampleState other)
     {
         sample = other.sample.clone();
+        arrayType = other.arrayType;
+        this.initialSample = other.initialSample;
+        this.initialSeenCount = other.initialSeenCount;
     }
 
-    public ReservoirSampleState(ReservoirSample sample)
+    public void initializeInitialSample(Block initialSample)
     {
-        this.sample = sample;
+        if (this.initialSample == null) {
+            this.initialSample = initialSample;
+        }
+    }
+
+    public void initializeInitialSeenCount(long initialSeenCount)
+    {
+        if (this.initialSeenCount < 0) {
+            this.initialSeenCount = initialSeenCount;
+        }
     }
 
     public void add(Block block, int position, long n)
     {
-        isEmpty = false;
-        if (!sample.isSampleInitialized()) {
-            sample.initializeSample(n);
-        }
-        sample.add(block, position);
+        sample.add(block, position, n);
     }
 
     public void setSample(ReservoirSample sample)
@@ -62,6 +77,8 @@ public class ReservoirSampleState
     public void mergeWith(ReservoirSampleState otherState)
     {
         sample.merge(otherState.sample);
+        initializeInitialSample(otherState.getInitialSample());
+        initializeInitialSeenCount(otherState.getInitialSeenCount());
     }
 
     public ReservoirSample getSamples()
@@ -69,13 +86,20 @@ public class ReservoirSampleState
         return sample;
     }
 
-    public void serialize(BlockBuilder out)
+    public Block getInitialSample()
     {
-        sample.serialize(out);
+        return initialSample;
     }
 
-    public boolean isEmpty()
+    public long getInitialSeenCount()
     {
-        return isEmpty;
+        return initialSeenCount;
+    }
+
+    public void serialize(BlockBuilder out)
+    {
+        arrayType.appendTo(initialSample, 0, out);
+        BIGINT.writeLong(out, initialSeenCount);
+        sample.serialize(out);
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/operator/aggregation/reservoirsample/ReservoirSampleState.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/aggregation/reservoirsample/ReservoirSampleState.java
@@ -13,6 +13,7 @@
  */
 package com.facebook.presto.operator.aggregation.reservoirsample;
 
+import com.facebook.presto.common.block.ArrayBlockBuilder;
 import com.facebook.presto.common.block.Block;
 import com.facebook.presto.common.block.BlockBuilder;
 import com.facebook.presto.common.type.ArrayType;
@@ -34,6 +35,7 @@ public class ReservoirSampleState
     {
         sample = new ReservoirSample(type);
         arrayType = new ArrayType(type);
+        initialSample = new ArrayBlockBuilder(arrayType, null, 1).appendNull().build();
     }
 
     public ReservoirSampleState(ReservoirSampleState other)
@@ -44,16 +46,10 @@ public class ReservoirSampleState
         this.initialSeenCount = other.initialSeenCount;
     }
 
-    public void initializeInitialSample(Block initialSample)
-    {
-        if (this.initialSample == null) {
-            this.initialSample = initialSample;
-        }
-    }
-
-    public void initializeInitialSeenCount(long initialSeenCount)
+    public void initializeInitialSample(Block initialSample, long initialSeenCount)
     {
         if (this.initialSeenCount < 0) {
+            this.initialSample = initialSample;
             this.initialSeenCount = initialSeenCount;
         }
     }
@@ -77,8 +73,7 @@ public class ReservoirSampleState
     public void mergeWith(ReservoirSampleState otherState)
     {
         sample.merge(otherState.sample);
-        initializeInitialSample(otherState.getInitialSample());
-        initializeInitialSeenCount(otherState.getInitialSeenCount());
+        initializeInitialSample(otherState.getInitialSample(), otherState.getInitialSeenCount());
     }
 
     public ReservoirSample getSamples()

--- a/presto-main/src/main/java/com/facebook/presto/operator/aggregation/reservoirsample/ReservoirSampleStateSerializer.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/aggregation/reservoirsample/ReservoirSampleStateSerializer.java
@@ -81,7 +81,6 @@ public class ReservoirSampleStateSerializer
         }
         ReservoirSample reservoirSample = new ReservoirSample(elementType, seenCount, maxSampleSize, samples);
         state.setSample(reservoirSample);
-        state.initializeInitialSample(initialSample);
-        state.initializeInitialSeenCount(initialSeenCount);
+        state.initializeInitialSample(initialSample, initialSeenCount);
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/operator/aggregation/reservoirsample/ReservoirSampleStateSerializer.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/aggregation/reservoirsample/ReservoirSampleStateSerializer.java
@@ -21,10 +21,12 @@ import com.facebook.presto.common.type.RowType.Field;
 import com.facebook.presto.common.type.Type;
 import com.facebook.presto.spi.function.AccumulatorStateSerializer;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
 
+import static com.facebook.presto.common.type.BigintType.BIGINT;
 import static com.facebook.presto.common.type.IntegerType.INTEGER;
 
 public class ReservoirSampleStateSerializer
@@ -35,13 +37,6 @@ public class ReservoirSampleStateSerializer
 
     public ReservoirSampleStateSerializer(Type elementType)
     {
-//        assert elementType instanceof RowType;
-//        RowType sampleRows = (RowType) elementType;
-//        List<Field> sampleFields = sampleRows.getFields();
-//        Field count = new Field(Optional.of("rowCount"), INTEGER);
-//        Field length = new Field(Optional.of("sampleLength"), INTEGER);
-//        sampleFields.add(count);
-//        sampleFields.add(length);
         this.elementType = elementType;
         this.arrayType = new ArrayType(elementType);
     }
@@ -49,24 +44,22 @@ public class ReservoirSampleStateSerializer
     @Override
     public Type getSerializedType()
     {
-        Field count = new Field(Optional.of("count"), INTEGER);
+        Field initialSample = new Field(Optional.of("initialSample"), arrayType);
+        Field initialSeenCount = new Field(Optional.of("initialSeenCount"), BIGINT);
+        Field seenCount = new Field(Optional.of("seenCount"), BIGINT);
+        Field maxSampleSize = new Field(Optional.of("maxSampleSize"), INTEGER);
         Field length = new Field(Optional.of("sampleLength"), INTEGER);
         Field sample = new Field(Optional.of("sample"), arrayType);
-        List<Field> fields = Arrays.asList(count, length, sample);
+        List<Field> fields = Arrays.asList(initialSample, initialSeenCount, seenCount, maxSampleSize, length, sample);
         return RowType.from(fields);
     }
 
     @Override
     public void serialize(ReservoirSampleState state, BlockBuilder out)
     {
-        if (state.isEmpty()) {
-            out.appendNull();
-        }
-        else {
-            BlockBuilder entryBuilder = out.beginBlockEntry();
-            state.serialize(entryBuilder);
-            out.closeEntry();
-        }
+        BlockBuilder entryBuilder = out.beginBlockEntry();
+        state.serialize(entryBuilder);
+        out.closeEntry();
     }
 
     @Override
@@ -74,16 +67,21 @@ public class ReservoirSampleStateSerializer
     {
         Type rowTypes = getSerializedType();
         Block stateBlock = (Block) rowTypes.getObject(block, index);
-        int seenCount = stateBlock.getInt(0);
-        int sampleLength = stateBlock.getInt(1);
-        Block samplesBlock = (Block) arrayType.getObject(stateBlock, 2);
-        Block[] samples = new Block[sampleLength];
+        Block initialSample = (Block) arrayType.getObject(stateBlock, 0);
+        long initialSeenCount = stateBlock.getLong(1);
+        long seenCount = stateBlock.getLong(2);
+        int maxSampleSize = stateBlock.getInt(3);
+        int sampleLength = stateBlock.getInt(4);
+        Block samplesBlock = (Block) arrayType.getObject(stateBlock, 5);
+        ArrayList<Block> samples = new ArrayList<>(sampleLength);
         for (int i = 0; i < sampleLength; i++) {
-            BlockBuilder elementBlock = elementType.createBlockBuilder(null, 16);
+            BlockBuilder elementBlock = elementType.createBlockBuilder(null, 1);
             elementType.appendTo(samplesBlock, i, elementBlock);
-            samples[i] = elementBlock.build();
+            samples.add(elementBlock.build());
         }
-        ReservoirSample reservoirSample = new ReservoirSample(seenCount, samples, elementType);
+        ReservoirSample reservoirSample = new ReservoirSample(elementType, seenCount, maxSampleSize, samples);
         state.setSample(reservoirSample);
+        state.initializeInitialSample(initialSample);
+        state.initializeInitialSeenCount(initialSeenCount);
     }
 }


### PR DESCRIPTION
Two new arguments are added to the signature of the reservoir_sample
function which indicate an array of existing samples and the total
number of samples processed to generate that sample.

Additionally, the output signature now uses named fields in order to be
able to select the seen count and samples individually.

I changed the structure of the ReservoirampleState and
ReservoirSample classes to not use a boolean to track "isEmpty" and
use a boolean function to calculate it. In place of using the "isEmpty"
variables, we track the current "maxSampleSize" versus the actual size,
"samples.size()". This is the main reasoning for switching to an
ArrayList. There should be no performance impact as long as the
ArrayList is always initialized with the expected max count.

Lastly, some optimizations were made to correctly pass the expected
block sizes to a few of the block builder methods.