### PR TITLE
Fix ndv inefficiency issue and update initial table statistics after analyze on sample table

### DIFF
--- a/presto-hive-metastore/src/main/java/com/facebook/presto/hive/metastore/Statistics.java
+++ b/presto-hive-metastore/src/main/java/com/facebook/presto/hive/metastore/Statistics.java
@@ -393,7 +393,12 @@ public final class Statistics
                 Type ndvEstimatorOutputType = RowType.from(Arrays.asList(
                         new RowType.Field(Optional.of("ndv"), BIGINT), new RowType.Field(Optional.of("errorBound"), DOUBLE)));
                 Block ndvRowBlock = (Block) ndvEstimatorOutputType.getObject(ndvBlock, 0);
-                result.setDistinctValuesCount(ndvRowBlock.getLong(0));
+                if (ndvRowBlock.getLong(0) == -1) {
+                    result.setDistinctValuesCount(rowCount);
+                }
+                else {
+                    result.setDistinctValuesCount(ndvRowBlock.getLong(0));
+                }
             }
             else {
                 numberOfDistinctValues = BIGINT.getLong(ndvBlock, 0);

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergAbstractMetadata.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergAbstractMetadata.java
@@ -606,7 +606,12 @@ public abstract class IcebergAbstractMetadata
                 builder.setColumnStatistics(ch, colBuilder.build());
             });
         });
-        statsCache.put((IcebergTableHandle) tableHandle, builder.build());
+        if (useSampleForAnalyze) {
+            statsCache.put((IcebergTableHandle) getTableHandle(session, ((IcebergTableHandle) tableHandle).getSchemaTableName()), builder.build());
+        }
+        else {
+            statsCache.put((IcebergTableHandle) tableHandle, builder.build());
+        }
     }
 
     private static Optional<DoubleRange> createRange(com.facebook.presto.common.type.Type type, HiveColumnStatistics statistics)

--- a/presto-main/src/main/java/com/facebook/presto/operator/aggregation/estimatendv/SingleNDVEstimatorState.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/aggregation/estimatendv/SingleNDVEstimatorState.java
@@ -20,7 +20,6 @@ import com.facebook.presto.operator.aggregation.histogram.SingleTypedHistogram;
 
 import java.util.HashMap;
 import java.util.Map;
-import java.util.stream.LongStream;
 
 public class SingleNDVEstimatorState
         extends SingleHistogramState

--- a/presto-main/src/main/java/com/facebook/presto/operator/aggregation/estimatendv/SingleNDVEstimatorState.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/aggregation/estimatendv/SingleNDVEstimatorState.java
@@ -63,17 +63,18 @@ public class SingleNDVEstimatorState
     private long computeBirthdayProblemProbability(long d)
     {
         long i = d;
-        long lowerBound;
-        while (true) {
-            lowerBound = d + i;
-            long finalLowerBound = lowerBound;
-            double multiplied = LongStream.range(0, d).mapToDouble(j -> (double) (finalLowerBound - j) / finalLowerBound).reduce(1, (x, y) -> x * y);
+        while (true) {  // try different lower bounds
+            long lowerBound = d + i;
+            double multiplied = 1;
+            for (int j = 0; j < d; j++) {
+                multiplied *= (double) (lowerBound - j) / lowerBound;
+            }
             if (multiplied > LOWER_BOUND_PROBABILITY) {
                 break;
             }
-            i += 1;
+            i++;
         }
-        return lowerBound;
+        return d + i;
     }
 
     /**
@@ -98,7 +99,7 @@ public class SingleNDVEstimatorState
             totalValues += key * freqDict.get(key);
         }
         if (distinctValues == totalValues) {
-            return new Object[] {computeBirthdayProblemProbability(distinctValues)};
+            return new Object[] {-1L};
         }
         // if 1 not in freqDict
         if (!freqDict.containsKey(1L)) {


### PR DESCRIPTION
 When `ndv=rowcount` in the sample, guess the ndv in the initial table as the table row count.
Write the stat collected from sample table to the initial table stats